### PR TITLE
Fix tidy issues

### DIFF
--- a/src/librustc_target/abi/call/xtensa.rs
+++ b/src/librustc_target/abi/call/xtensa.rs
@@ -1,12 +1,11 @@
 // reference: https://github.com/espressif/clang-xtensa/commit/6fb488d2553f06029e6611cf81c6efbd45b56e47#diff-aa74ae1e1ab6b7149789237edb78e688R8450
 
-
 use crate::abi::call::{ArgType, FnType, Reg, Uniform};
 
 const NUM_ARG_GPR: u64 = 6;
-const MAX_ARG_IN_REGS_SIZE: u64  = 4 * 32;
+const MAX_ARG_IN_REGS_SIZE: u64 = 4 * 32;
 // const MAX_ARG_DIRECT_SIZE: u64 = MAX_ARG_IN_REGS_SIZE;
-const MAX_RET_IN_REGS_SIZE: u64  = 2 * 32;
+const MAX_RET_IN_REGS_SIZE: u64 = 2 * 32;
 
 fn classify_ret_ty<Ty>(arg: &mut ArgType<'_, Ty>, xlen: u64) {
     // The rules for return and argument types are the same, so defer to
@@ -14,12 +13,11 @@ fn classify_ret_ty<Ty>(arg: &mut ArgType<'_, Ty>, xlen: u64) {
     classify_arg_ty(arg, xlen, &mut 2); // two as max return size
 }
 
-
 fn classify_arg_ty<Ty>(arg: &mut ArgType<'_, Ty>, xlen: u64, remaining_gpr: &mut u64) {
     // Determine the number of GPRs needed to pass the current argument
     // according to the ABI. 2*XLen-aligned varargs are passed in "aligned"
     // register pairs, so may consume 3 registers.
-    
+
     let arg_size = arg.layout.size;
     if arg_size.bits() > MAX_ARG_IN_REGS_SIZE {
         arg.make_indirect();
@@ -31,7 +29,7 @@ fn classify_arg_ty<Ty>(arg: &mut ArgType<'_, Ty>, xlen: u64, remaining_gpr: &mut
 
     if alignment.bits() == 2 * xlen {
         required_gpr = 2 + (*remaining_gpr % 2);
-    } else if  arg_size.bits() > xlen && arg_size.bits() <= MAX_ARG_IN_REGS_SIZE {
+    } else if arg_size.bits() > xlen && arg_size.bits() <= MAX_ARG_IN_REGS_SIZE {
         required_gpr = (arg_size.bits() + (xlen - 1)) / xlen;
     }
 
@@ -44,14 +42,16 @@ fn classify_arg_ty<Ty>(arg: &mut ArgType<'_, Ty>, xlen: u64, remaining_gpr: &mut
 
     // if  a value can fit in a reg and the
     // stack is not required, extend
-    if !arg.layout.is_aggregate() { // non-aggregate types
+    if !arg.layout.is_aggregate() {
+        // non-aggregate types
         if arg_size.bits() < xlen && !stack_required {
             arg.extend_integer_width_to(xlen);
         }
-    } else if arg_size.bits() as u64 <= MAX_ARG_IN_REGS_SIZE { // aggregate types
+    } else if arg_size.bits() as u64 <= MAX_ARG_IN_REGS_SIZE {
+        // aggregate types
         // Aggregates which are <= 4*32 will be passed in registers if possible,
         // so coerce to integers.
-        
+
         // Use a single XLen int if possible, 2*XLen if 2*XLen alignment is
         // required, and a 2-element XLen array if only XLen alignment is
         // required.
@@ -61,33 +61,26 @@ fn classify_arg_ty<Ty>(arg: &mut ArgType<'_, Ty>, xlen: u64, remaining_gpr: &mut
         //     arg.extend_integer_width_to(arg_size + (xlen - 1) / xlen);
         // }
         if alignment.bits() == 2 * xlen {
-            arg.cast_to(Uniform {
-                unit: Reg::i64(),
-                total: arg_size
-            });
+            arg.cast_to(Uniform { unit: Reg::i64(), total: arg_size });
         } else {
-            //TODO array type - this should be a homogenous array type
+            //FIXME array type - this should be a homogenous array type
             // arg.extend_integer_width_to(arg_size + (xlen - 1) / xlen);
         }
-        
     } else {
         // if we get here the stack is required
         assert!(stack_required);
         arg.make_indirect();
     }
 
-
-   // if arg_size as u64 <= MAX_ARG_IN_REGS_SIZE {
-   //     let align = arg.layout.align.abi.bytes();
-   //     let total = arg.layout.size;
-   //     arg.cast_to(Uniform {
-   //         unit: if align <= 4 { Reg::i32() } else { Reg::i64() },
-   //         total
-   //     });
-   //     return;
-   // }
-        
-    
+    // if arg_size as u64 <= MAX_ARG_IN_REGS_SIZE {
+    //     let align = arg.layout.align.abi.bytes();
+    //     let total = arg.layout.size;
+    //     arg.cast_to(Uniform {
+    //         unit: if align <= 4 { Reg::i32() } else { Reg::i64() },
+    //         total
+    //     });
+    //     return;
+    // }
 }
 
 pub fn compute_abi_info<Ty>(fty: &mut FnType<'_, Ty>, xlen: u64) {
@@ -95,14 +88,10 @@ pub fn compute_abi_info<Ty>(fty: &mut FnType<'_, Ty>, xlen: u64) {
         classify_ret_ty(&mut fty.ret, xlen);
     }
 
-    let return_indirect = fty.ret.layout.size.bits() > MAX_RET_IN_REGS_SIZE ||
-                            fty.ret.is_indirect();
+    let return_indirect =
+        fty.ret.layout.size.bits() > MAX_RET_IN_REGS_SIZE || fty.ret.is_indirect();
 
-    let mut remaining_gpr = if return_indirect {
-        NUM_ARG_GPR - 1
-    } else {
-        NUM_ARG_GPR
-    };
+    let mut remaining_gpr = if return_indirect { NUM_ARG_GPR - 1 } else { NUM_ARG_GPR };
 
     for arg in &mut fty.args {
         if arg.is_ignore() {

--- a/src/librustc_target/spec/xtensa_esp32_none_elf.rs
+++ b/src/librustc_target/spec/xtensa_esp32_none_elf.rs
@@ -1,4 +1,4 @@
-use crate::spec::{LinkerFlavor, PanicStrategy, Target, TargetOptions, TargetResult, abi::Abi}; 
+use crate::spec::{abi::Abi, LinkerFlavor, PanicStrategy, Target, TargetOptions, TargetResult};
 // use crate::spec::abi::Abi;
 
 pub fn target() -> TargetResult {
@@ -60,7 +60,7 @@ pub fn target() -> TargetResult {
                 Abi::SysV64,
             ],
 
-            .. Default::default( )
-        }
+            ..Default::default()
+        },
     })
 }

--- a/src/librustc_target/spec/xtensa_esp8266_none_elf.rs
+++ b/src/librustc_target/spec/xtensa_esp8266_none_elf.rs
@@ -1,4 +1,4 @@
-use crate::spec::{LinkerFlavor, PanicStrategy, Target, TargetOptions, TargetResult, abi::Abi}; 
+use crate::spec::{abi::Abi, LinkerFlavor, PanicStrategy, Target, TargetOptions, TargetResult};
 // use crate::spec::abi::Abi;
 
 pub fn target() -> TargetResult {
@@ -60,7 +60,7 @@ pub fn target() -> TargetResult {
                 Abi::SysV64,
             ],
 
-            .. Default::default( )
-        }
+            ..Default::default()
+        },
     })
 }

--- a/src/librustc_target/spec/xtensa_none_elf.rs
+++ b/src/librustc_target/spec/xtensa_none_elf.rs
@@ -1,4 +1,4 @@
-use crate::spec::{LinkerFlavor, PanicStrategy, Target, TargetOptions, TargetResult, abi::Abi}; 
+use crate::spec::{abi::Abi, LinkerFlavor, PanicStrategy, Target, TargetOptions, TargetResult};
 // use crate::spec::abi::Abi;
 
 pub fn target() -> TargetResult {
@@ -60,7 +60,7 @@ pub fn target() -> TargetResult {
                 Abi::SysV64,
             ],
 
-            .. Default::default( )
-        }
+            ..Default::default()
+        },
     })
 }


### PR DESCRIPTION
Fixes the following errors during testing by formatting the files.

```
tidy check
tidy error: /Users/ferdiamckeogh/Desktop/rust/src/librustc_target/spec/xtensa_esp8266_none_elf.rs:1: trailing whitespace
tidy error: /Users/ferdiamckeogh/Desktop/rust/src/librustc_target/spec/xtensa_esp32_none_elf.rs:1: trailing whitespace
tidy error: /Users/ferdiamckeogh/Desktop/rust/src/librustc_target/spec/xtensa_none_elf.rs:1: trailing whitespace
tidy error: /Users/ferdiamckeogh/Desktop/rust/src/librustc_target/abi/call/xtensa.rs:22: trailing whitespace
tidy error: /Users/ferdiamckeogh/Desktop/rust/src/librustc_target/abi/call/xtensa.rs:54: trailing whitespace
tidy error: /Users/ferdiamckeogh/Desktop/rust/src/librustc_target/abi/call/xtensa.rs:69: TODO is deprecated; use FIXME
tidy error: /Users/ferdiamckeogh/Desktop/rust/src/librustc_target/abi/call/xtensa.rs:72: trailing whitespace
tidy error: /Users/ferdiamckeogh/Desktop/rust/src/librustc_target/abi/call/xtensa.rs:89: trailing whitespace
tidy error: /Users/ferdiamckeogh/Desktop/rust/src/librustc_target/abi/call/xtensa.rs:90: trailing whitespace
some tidy checks failed
```