### PR TITLE
Rust STD support for the ESP-IDF framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,7 +110,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
- "libc",
+ "libc 0.2.93",
  "winapi 0.3.9",
 ]
 
@@ -176,7 +176,7 @@ dependencies = [
  "getopts",
  "ignore",
  "lazy_static",
- "libc",
+ "libc 0.2.93",
  "merge",
  "num_cpus",
  "opener",
@@ -281,7 +281,7 @@ dependencies = [
  "jobserver",
  "lazy_static",
  "lazycell",
- "libc",
+ "libc 0.2.93",
  "libgit2-sys",
  "log",
  "memchr",
@@ -391,7 +391,7 @@ dependencies = [
  "filetime",
  "hex 0.4.2",
  "jobserver",
- "libc",
+ "libc 0.2.93",
  "log",
  "miow 0.3.6",
  "same-file",
@@ -523,7 +523,7 @@ version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
- "libc",
+ "libc 0.2.93",
  "num-integer",
  "num-traits",
  "time",
@@ -649,7 +649,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fed34f46747aa73dfaa578069fd8279d2818ade2b55f38f22a9401c7f4083e2"
 dependencies = [
- "libc",
+ "libc 0.2.93",
 ]
 
 [[package]]
@@ -671,7 +671,7 @@ dependencies = [
  "getopts",
  "glob",
  "lazy_static",
- "libc",
+ "libc 0.2.93",
  "miow 0.3.6",
  "regex",
  "rustfix",
@@ -694,7 +694,7 @@ dependencies = [
  "filetime",
  "getopts",
  "lazy_static",
- "libc",
+ "libc 0.2.93",
  "log",
  "miow 0.3.6",
  "regex",
@@ -721,7 +721,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b5ed8e7e76c45974e15e41bfa8d5b0483cd90191639e01d8f5f1e606299d3fb"
 dependencies = [
  "core-foundation-sys",
- "libc",
+ "libc 0.2.93",
 ]
 
 [[package]]
@@ -869,7 +869,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e268162af1a5fe89917ae25ba3b0a77c8da752bdc58e7dbb4f15b91fbd33756e"
 dependencies = [
  "curl-sys",
- "libc",
+ "libc 0.2.93",
  "openssl-probe",
  "openssl-sys",
  "schannel",
@@ -884,7 +884,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07a8ce861e7b68a0b394e814d7ee9f1b2750ff8bd10372c6ad3bacc10e86f874"
 dependencies = [
  "cc",
- "libc",
+ "libc 0.2.93",
  "libnghttp2-sys",
  "libz-sys",
  "openssl-sys",
@@ -986,7 +986,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
 dependencies = [
- "libc",
+ "libc 0.2.93",
  "redox_users",
  "winapi 0.3.9",
 ]
@@ -997,7 +997,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
- "libc",
+ "libc 0.2.93",
  "redox_users",
  "winapi 0.3.9",
 ]
@@ -1009,7 +1009,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "332570860c2edf2d57914987bf9e24835425f75825086b6ba7d1e6a3e4f1f254"
 dependencies = [
  "compiler_builtins",
- "libc",
+ "libc 0.2.93",
  "rustc-std-workspace-core",
 ]
 
@@ -1141,7 +1141,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed85775dcc68644b5c950ac06a2b23768d3bc9390464151aaf27136998dcf9e"
 dependencies = [
  "cfg-if 0.1.10",
- "libc",
+ "libc 0.2.93",
  "redox_syscall 0.1.57",
  "winapi 0.3.9",
 ]
@@ -1160,7 +1160,7 @@ checksum = "68c90b0fc46cf89d227cc78b40e494ff81287a92dd07631e5af0d06fe3cf885e"
 dependencies = [
  "cfg-if 0.1.10",
  "crc32fast",
- "libc",
+ "libc 0.2.93",
  "libz-sys",
  "miniz_oxide",
 ]
@@ -1390,7 +1390,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 dependencies = [
  "cfg-if 0.1.10",
- "libc",
+ "libc 0.2.93",
  "wasi",
 ]
 
@@ -1401,7 +1401,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee8025cf36f917e6a52cce185b7c7177689b838b7ec138364e50cc2277a56cf4"
 dependencies = [
  "cfg-if 0.1.10",
- "libc",
+ "libc 0.2.93",
  "wasi",
 ]
 
@@ -1435,7 +1435,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d250f5f82326884bd39c2853577e70a121775db76818ffa452ed1e80de12986"
 dependencies = [
  "bitflags",
- "libc",
+ "libc 0.2.93",
  "libgit2-sys",
  "log",
  "openssl-probe",
@@ -1530,7 +1530,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
 dependencies = [
  "compiler_builtins",
- "libc",
+ "libc 0.2.93",
  "rustc-std-workspace-core",
 ]
 
@@ -1683,7 +1683,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
- "libc",
+ "libc 0.2.93",
 ]
 
 [[package]]
@@ -1716,7 +1716,7 @@ version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "972f5ae5d1cb9c6ae417789196c803205313edde988685da5e3aae0827b9e7fd"
 dependencies = [
- "libc",
+ "libc 0.2.93",
 ]
 
 [[package]]
@@ -1885,13 +1885,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "libc"
+version = "0.2.98"
+source = "git+https://github.com/ivmarkov/libc.git?branch=version_0.2.98#fc4abdb5fcf97212332478709760729f1563e9e0"
+dependencies = [
+ "rustc-std-workspace-core",
+]
+
+[[package]]
 name = "libgit2-sys"
 version = "0.12.18+1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3da6a42da88fc37ee1ecda212ffa254c25713532980005d5f7c0b0fbe7e6e885"
 dependencies = [
  "cc",
- "libc",
+ "libc 0.2.93",
  "libssh2-sys",
  "libz-sys",
  "openssl-sys",
@@ -1911,7 +1919,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03624ec6df166e79e139a2310ca213283d6b3c30810c54844f307086d4488df1"
 dependencies = [
  "cc",
- "libc",
+ "libc 0.2.93",
 ]
 
 [[package]]
@@ -1921,7 +1929,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca46220853ba1c512fc82826d0834d87b06bcd3c2a42241b7de72f3d2fe17056"
 dependencies = [
  "cc",
- "libc",
+ "libc 0.2.93",
  "libz-sys",
  "openssl-sys",
  "pkg-config",
@@ -1935,7 +1943,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "602113192b08db8f38796c4e85c39e960c145965140e918018bcde1952429655"
 dependencies = [
  "cc",
- "libc",
+ "libc 0.2.93",
  "pkg-config",
  "vcpkg",
 ]
@@ -2012,7 +2020,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f24f76ec44a8ac23a31915d6e326bca17ce88da03096f1ff194925dc714dac99"
 dependencies = [
  "cc",
- "libc",
+ "libc 0.2.93",
  "pkg-config",
 ]
 
@@ -2148,7 +2156,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
 dependencies = [
- "libc",
+ "libc 0.2.93",
  "winapi 0.3.9",
 ]
 
@@ -2158,7 +2166,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04e3e85b970d650e2ae6d70592474087051c11c54da7f7b4949725c5735fbcc6"
 dependencies = [
- "libc",
+ "libc 0.2.93",
 ]
 
 [[package]]
@@ -2224,7 +2232,7 @@ dependencies = [
  "fuchsia-zircon-sys",
  "iovec",
  "kernel32-sys",
- "libc",
+ "libc 0.2.93",
  "log",
  "miow 0.2.2",
  "net2",
@@ -2251,7 +2259,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
 dependencies = [
  "iovec",
- "libc",
+ "libc 0.2.93",
  "mio",
 ]
 
@@ -2286,7 +2294,7 @@ dependencies = [
  "env_logger 0.8.1",
  "getrandom 0.2.0",
  "hex 0.4.2",
- "libc",
+ "libc 0.2.93",
  "log",
  "rand 0.8.3",
  "rustc-workspace-hack",
@@ -2302,7 +2310,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7cf75f38f16cb05ea017784dc6dbfd354f76c223dba37701734c4f5a9337d02"
 dependencies = [
  "cfg-if 0.1.10",
- "libc",
+ "libc 0.2.93",
  "winapi 0.3.9",
 ]
 
@@ -2338,7 +2346,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
- "libc",
+ "libc 0.2.93",
 ]
 
 [[package]]
@@ -2398,7 +2406,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "foreign-types",
  "lazy_static",
- "libc",
+ "libc 0.2.93",
  "openssl-sys",
 ]
 
@@ -2425,7 +2433,7 @@ checksum = "a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de"
 dependencies = [
  "autocfg",
  "cc",
- "libc",
+ "libc 0.2.93",
  "openssl-src",
  "pkg-config",
  "vcpkg",
@@ -2464,7 +2472,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "compiler_builtins",
  "core",
- "libc",
+ "libc 0.2.98",
 ]
 
 [[package]]
@@ -2475,7 +2483,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "compiler_builtins",
  "core",
- "libc",
+ "libc 0.2.98",
  "unwind",
 ]
 
@@ -2486,7 +2494,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd7f6c69d7687501b2205fe51ade1d7b8797bb3aa141fe5bf13dd78c0483bc89"
 dependencies = [
  "futures 0.3.12",
- "libc",
+ "libc 0.2.93",
  "log",
  "mio-named-pipes",
  "miow 0.3.6",
@@ -2514,7 +2522,7 @@ checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
 dependencies = [
  "cfg-if 1.0.0",
  "instant",
- "libc",
+ "libc 0.2.93",
  "redox_syscall 0.2.5",
  "smallvec",
  "winapi 0.3.9",
@@ -2544,7 +2552,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce9bedf5da2c234fdf2391ede2b90fabf585355f33100689bc364a3ea558561a"
 dependencies = [
- "libc",
+ "libc 0.2.93",
 ]
 
 [[package]]
@@ -2872,7 +2880,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom 0.1.14",
- "libc",
+ "libc 0.2.93",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
@@ -2885,7 +2893,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
 dependencies = [
- "libc",
+ "libc 0.2.93",
  "rand_chacha 0.3.0",
  "rand_core 0.6.2",
  "rand_hc 0.3.0",
@@ -3258,7 +3266,7 @@ dependencies = [
  "ena",
  "indexmap",
  "jobserver",
- "libc",
+ "libc 0.2.93",
  "measureme",
  "memmap2",
  "parking_lot",
@@ -3536,7 +3544,7 @@ version = "1.0.0"
 dependencies = [
  "byteorder",
  "crossbeam-utils 0.8.3",
- "libc",
+ "libc 0.2.93",
  "libz-sys",
  "proc-macro2",
  "quote",
@@ -3667,7 +3675,7 @@ version = "0.0.0"
 dependencies = [
  "bitflags",
  "cstr",
- "libc",
+ "libc 0.2.93",
  "measureme",
  "rustc-demangle",
  "rustc_ast",
@@ -3699,7 +3707,7 @@ dependencies = [
  "cc",
  "itertools 0.9.0",
  "jobserver",
- "libc",
+ "libc 0.2.93",
  "pathdiff",
  "rustc_apfloat",
  "rustc_ast",
@@ -3732,7 +3740,7 @@ dependencies = [
  "ena",
  "indexmap",
  "jobserver",
- "libc",
+ "libc 0.2.93",
  "measureme",
  "memmap2",
  "parking_lot",
@@ -3756,7 +3764,7 @@ name = "rustc_driver"
 version = "0.0.0"
 dependencies = [
  "atty",
- "libc",
+ "libc 0.2.93",
  "rustc_ast",
  "rustc_ast_pretty",
  "rustc_codegen_ssa",
@@ -3924,7 +3932,7 @@ dependencies = [
 name = "rustc_interface"
 version = "0.0.0"
 dependencies = [
- "libc",
+ "libc 0.2.93",
  "rustc-rayon",
  "rustc-rayon-core",
  "rustc_ast",
@@ -4016,7 +4024,7 @@ version = "0.0.0"
 dependencies = [
  "build_helper",
  "cc",
- "libc",
+ "libc 0.2.93",
 ]
 
 [[package]]
@@ -4033,7 +4041,7 @@ dependencies = [
 name = "rustc_metadata"
 version = "0.0.0"
 dependencies = [
- "libc",
+ "libc 0.2.93",
  "rustc_ast",
  "rustc_attr",
  "rustc_data_structures",
@@ -4632,7 +4640,7 @@ dependencies = [
  "bitflags",
  "core-foundation",
  "core-foundation-sys",
- "libc",
+ "libc 0.2.93",
  "security-framework-sys",
 ]
 
@@ -4643,7 +4651,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f99b9d5e26d2a71633cc4f2ebae7cc9f874044e0c351a27e17892d76dce5678b"
 dependencies = [
  "core-foundation-sys",
- "libc",
+ "libc 0.2.93",
 ]
 
 [[package]]
@@ -4814,7 +4822,7 @@ version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce32ea0c6c56d5eacaeb814fbed9960547021d3edd010ded1425f180536b20ab"
 dependencies = [
- "libc",
+ "libc 0.2.93",
 ]
 
 [[package]]
@@ -4858,7 +4866,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fd8b795c389288baa5f355489c65e71fd48a02104600d15c4cfbc561e9e429d"
 dependencies = [
  "cfg-if 0.1.10",
- "libc",
+ "libc 0.2.93",
  "redox_syscall 0.1.57",
  "winapi 0.3.9",
 ]
@@ -4877,7 +4885,7 @@ checksum = "21ccb4c06ec57bc82d0f610f1a2963d7648700e43a6f513e564b9c89f7991786"
 dependencies = [
  "cc",
  "cfg-if 0.1.10",
- "libc",
+ "libc 0.2.93",
  "psm",
  "winapi 0.3.9",
 ]
@@ -4895,7 +4903,7 @@ dependencies = [
  "fortanix-sgx-abi",
  "hashbrown 0.11.0",
  "hermit-abi",
- "libc",
+ "libc 0.2.98",
  "miniz_oxide",
  "object",
  "panic_abort",
@@ -4914,7 +4922,7 @@ version = "0.1.5"
 dependencies = [
  "cfg-if 0.1.10",
  "compiler_builtins",
- "libc",
+ "libc 0.2.93",
  "rustc-std-workspace-alloc",
  "rustc-std-workspace-core",
 ]
@@ -5031,7 +5039,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8a4c1d0bee3230179544336c15eefb563cf0302955d962e456542323e8c2e8a"
 dependencies = [
  "filetime",
- "libc",
+ "libc 0.2.93",
  "redox_syscall 0.1.57",
  "xattr",
 ]
@@ -5043,7 +5051,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
  "cfg-if 1.0.0",
- "libc",
+ "libc 0.2.93",
  "rand 0.8.3",
  "redox_syscall 0.2.5",
  "remove_dir_all",
@@ -5105,7 +5113,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1706be6b564323ce7092f5f7e6b118a14c8ef7ed0e69c8c5329c914a9f101295"
 dependencies = [
- "libc",
+ "libc 0.2.93",
  "winapi 0.3.9",
 ]
 
@@ -5116,7 +5124,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "core",
  "getopts",
- "libc",
+ "libc 0.2.93",
  "panic_abort",
  "panic_unwind",
  "proc_macro",
@@ -5132,7 +5140,7 @@ checksum = "0639d10d8f4615f223a57275cf40f9bdb7cfbb806bcb7f7cc56e3beb55a576eb"
 dependencies = [
  "cfg-if 1.0.0",
  "getopts",
- "libc",
+ "libc 0.2.93",
  "num_cpus",
  "term 0.7.0",
 ]
@@ -5198,7 +5206,7 @@ checksum = "8a26331b05179d4cb505c8d6814a7e18d298972f0a551b0e3cefccff927f86d3"
 dependencies = [
  "cc",
  "fs_extra",
- "libc",
+ "libc 0.2.93",
 ]
 
 [[package]]
@@ -5207,7 +5215,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c14a5a604eb8715bc5785018a37d00739b180bcf609916ddf4393d33d49ccdf"
 dependencies = [
- "libc",
+ "libc 0.2.93",
  "tikv-jemalloc-sys",
 ]
 
@@ -5217,7 +5225,7 @@ version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
- "libc",
+ "libc 0.2.93",
  "winapi 0.3.9",
 ]
 
@@ -5237,7 +5245,7 @@ dependencies = [
  "futures-core",
  "iovec",
  "lazy_static",
- "libc",
+ "libc 0.2.93",
  "memchr",
  "mio",
  "mio-named-pipes",
@@ -5506,7 +5514,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "compiler_builtins",
  "core",
- "libc",
+ "libc 0.2.98",
 ]
 
 [[package]]
@@ -5667,7 +5675,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
 dependencies = [
- "libc",
+ "libc 0.2.93",
 ]
 
 [[package]]

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -864,7 +864,9 @@ supported_targets! {
 
     ("riscv32i-unknown-none-elf", riscv32i_unknown_none_elf),
     ("riscv32imc-unknown-none-elf", riscv32imc_unknown_none_elf),
+    ("riscv32imc-esp-espidf", riscv32imc_esp_espidf),
     ("riscv32imac-unknown-none-elf", riscv32imac_unknown_none_elf),
+    ("riscv32imac-esp-espidf", riscv32imac_esp_espidf),
     ("riscv32gc-unknown-linux-gnu", riscv32gc_unknown_linux_gnu),
     ("riscv32gc-unknown-linux-musl", riscv32gc_unknown_linux_musl),
     ("riscv64imac-unknown-none-elf", riscv64imac_unknown_none_elf),

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -883,7 +883,9 @@ supported_targets! {
     ("nvptx64-nvidia-cuda", nvptx64_nvidia_cuda),
 
     ("xtensa-esp32-none-elf", xtensa_esp32_none_elf),
+    ("xtensa-esp32-espidf", xtensa_esp32_espidf),
     ("xtensa-esp32s2-none-elf", xtensa_esp32s2_none_elf),
+    ("xtensa-esp32s2-espidf", xtensa_esp32s2_espidf),
     ("xtensa-esp8266-none-elf", xtensa_esp8266_none_elf),
     ("xtensa-none-elf", xtensa_none_elf),
 

--- a/compiler/rustc_target/src/spec/riscv32imac_esp_espidf.rs
+++ b/compiler/rustc_target/src/spec/riscv32imac_esp_espidf.rs
@@ -1,0 +1,30 @@
+use crate::spec::{LinkerFlavor, PanicStrategy, RelocModel};
+use crate::spec::{Target, TargetOptions};
+
+pub fn target() -> Target {
+    Target {
+        data_layout: "e-m:e-p:32:32-i64:64-n32-S128".to_string(),
+        llvm_target: "riscv32".to_string(),
+        pointer_width: 32,
+        arch: "riscv32".to_string(),
+
+        options: TargetOptions {
+            os_family: Some("unix".to_string()),
+            os: "espidf".to_string(),
+            env: "newlib".to_string(),
+            vendor: "espressif".to_string(),
+            linker_flavor: LinkerFlavor::Gcc,
+            linker: Some("riscv32-esp-elf-gcc".to_string()),
+            cpu: "generic-rv32".to_string(),
+            max_atomic_width: Some(32),
+            features: "+m,+a,+c".to_string(),
+            executables: true,
+            panic_strategy: PanicStrategy::Abort,
+            relocation_model: RelocModel::Static,
+            emit_debug_gdb_scripts: false,
+            unsupported_abis: super::riscv_base::unsupported_abis(),
+            eh_frame_header: false,
+            ..Default::default()
+        },
+    }
+}

--- a/compiler/rustc_target/src/spec/riscv32imc_esp_espidf.rs
+++ b/compiler/rustc_target/src/spec/riscv32imc_esp_espidf.rs
@@ -1,0 +1,44 @@
+use crate::spec::{LinkerFlavor, PanicStrategy, RelocModel};
+use crate::spec::{Target, TargetOptions};
+
+pub fn target() -> Target {
+    Target {
+        data_layout: "e-m:e-p:32:32-i64:64-n32-S128".to_string(),
+        llvm_target: "riscv32".to_string(),
+        pointer_width: 32,
+        arch: "riscv32".to_string(),
+
+        options: TargetOptions {
+            os_family: Some("unix".to_string()),
+            os: "espidf".to_string(),
+            env: "newlib".to_string(),
+            vendor: "espressif".to_string(),
+            linker_flavor: LinkerFlavor::Gcc,
+            linker: Some("riscv32-esp-elf-gcc".to_string()),
+            cpu: "generic-rv32".to_string(),
+
+            // See https://github.com/espressif/rust-esp32-example/issues/3#issuecomment-861054477
+            //
+            // The RISCV32IMC architecture does not support atomics.
+            // However, simultaneously claiming "max_atomic_width: Some(32)" **and** "atomic_cas: true",
+            // forces the compiler to generate libcalls to functions that emulate atomics
+            // and which are already implemented in the ESP-IDF main branch anyway.
+            //
+            // The plan forward is as follows:
+            // - If the missing hardware instruction(s) end up being emulated in ESP-IDF, we will remove
+            //   this target altogether and use the riscv32imac-esp-espidf target with ESP-IDF
+            // - Otherwise, we'll use this target and remove the riscv32imac-esp-espidf one
+            max_atomic_width: Some(32),
+            atomic_cas: true,
+
+            features: "+m,+c".to_string(),
+            executables: true,
+            panic_strategy: PanicStrategy::Abort,
+            relocation_model: RelocModel::Static,
+            emit_debug_gdb_scripts: false,
+            unsupported_abis: super::riscv_base::unsupported_abis(),
+            eh_frame_header: false,
+            ..Default::default()
+        },
+    }
+}

--- a/compiler/rustc_target/src/spec/xtensa_esp32_espidf.rs
+++ b/compiler/rustc_target/src/spec/xtensa_esp32_espidf.rs
@@ -1,0 +1,51 @@
+use crate::spec::{abi::Abi, LinkerFlavor, PanicStrategy, Target, TargetOptions, RelocModel};
+use crate::abi::Endian;
+
+pub fn target() -> Target {
+    Target {
+        llvm_target: "xtensa-none-elf".to_string(),
+        pointer_width: 32,
+        data_layout: "e-m:e-p:32:32-i8:8:32-i16:16:32-i64:64-n32".to_string(),
+        arch: "xtensa".to_string(),
+
+        options: TargetOptions {
+            endian: Endian::Little,
+            c_int_width: "32".to_string(),
+            os_family: Some("unix".to_string()),
+            os: "espidf".to_string(),
+            env: "newlib".to_string(),
+            vendor: "espressif".to_string(),
+            linker_flavor: LinkerFlavor::Gcc,
+
+            executables: true,
+            cpu: "esp32".to_string(),
+            linker: Some("xtensa-esp32-elf-gcc".to_string()),
+
+            max_atomic_width: Some(32),
+
+            // Because these devices have very little resources having an
+            // unwinder is too onerous so we default to "abort" because the
+            // "unwind" strategy is very rare.
+            panic_strategy: PanicStrategy::Abort,
+
+            // Similarly, one almost always never wants to use relocatable
+            // code because of the extra costs it involves.
+            relocation_model: RelocModel::Static,
+
+            emit_debug_gdb_scripts: false,
+
+            unsupported_abis: vec![
+                Abi::Stdcall { unwind: false },
+                Abi::Stdcall { unwind: true },
+                Abi::Fastcall,
+                Abi::Vectorcall,
+                Abi::Thiscall { unwind: false },
+                Abi::Thiscall { unwind: true },
+                Abi::Win64,
+                Abi::SysV64,
+            ],
+
+            ..Default::default()
+        },
+    }
+}

--- a/compiler/rustc_target/src/spec/xtensa_esp32s2_espidf.rs
+++ b/compiler/rustc_target/src/spec/xtensa_esp32s2_espidf.rs
@@ -1,0 +1,62 @@
+use crate::spec::{abi::Abi, LinkerFlavor, PanicStrategy, Target, TargetOptions, RelocModel};
+use crate::abi::Endian;
+
+pub fn target() -> Target {
+    Target {
+        llvm_target: "xtensa-none-elf".to_string(),
+        pointer_width: 32,
+        data_layout: "e-m:e-p:32:32-i8:8:32-i16:16:32-i64:64-n32".to_string(),
+        arch: "xtensa".to_string(),
+
+        options: TargetOptions {
+            endian: Endian::Little,
+            c_int_width: "32".to_string(),
+            os_family: Some("unix".to_string()),
+            os: "espidf".to_string(),
+            env: "newlib".to_string(),
+            vendor: "espressif".to_string(),
+            linker_flavor: LinkerFlavor::Gcc,
+
+            executables: true,
+            cpu: "esp32-s2".to_string(),
+            linker: Some("xtensa-esp32s2-elf-gcc".to_string()),
+
+            // See https://github.com/espressif/rust-esp32-example/issues/3#issuecomment-861054477
+            //
+            // Unlike the original ESP32 chip, ESP32-S2 does not really support atomics.
+            // If the missing hardware instruction ends up being emulated in ESP-IDF, we might want to revert
+            // this change and claim that atomics are supported "in hardware" (even though they would be emulated
+            // by actually trapping the illegal instruction exception handler and calling into an ESP-IDF C emulation code).
+            //
+            // However, for now we simultaneously claim "max_atomic_width: Some(32)" **and** atomic_cas: true,
+            // which should force the compiler to generate libcalls to functions that emulate atomics
+            // and which are already implemented in the ESP-IDF main branch anyway.
+            max_atomic_width: Some(32),
+            atomic_cas: true,
+
+            // Because these devices have very little resources having an
+            // unwinder is too onerous so we default to "abort" because the
+            // "unwind" strategy is very rare.
+            panic_strategy: PanicStrategy::Abort,
+
+            // Similarly, one almost always never wants to use relocatable
+            // code because of the extra costs it involves.
+            relocation_model: RelocModel::Static,
+
+            emit_debug_gdb_scripts: false,
+
+            unsupported_abis: vec![
+                Abi::Stdcall { unwind: false },
+                Abi::Stdcall { unwind: true },
+                Abi::Fastcall,
+                Abi::Vectorcall,
+                Abi::Thiscall { unwind: false },
+                Abi::Thiscall { unwind: true },
+                Abi::Win64,
+                Abi::SysV64,
+            ],
+
+            ..Default::default()
+        },
+    }
+}

--- a/library/panic_abort/Cargo.toml
+++ b/library/panic_abort/Cargo.toml
@@ -16,5 +16,5 @@ doc = false
 alloc = { path = "../alloc" }
 cfg-if = { version = "0.1.8", features = ['rustc-dep-of-std'] }
 core = { path = "../core" }
-libc = { version = "0.2", default-features = false }
+libc = { git = "https://github.com/ivmarkov/libc.git", branch = "version_0.2.98", default-features = false }
 compiler_builtins = "0.1.0"

--- a/library/panic_unwind/Cargo.toml
+++ b/library/panic_unwind/Cargo.toml
@@ -15,7 +15,7 @@ doc = false
 [dependencies]
 alloc = { path = "../alloc" }
 core = { path = "../core" }
-libc = { version = "0.2", default-features = false }
+libc = { git = "https://github.com/ivmarkov/libc.git", branch = "version_0.2.98", default-features = false }
 unwind = { path = "../unwind" }
 compiler_builtins = "0.1.0"
 cfg-if = "0.1.8"

--- a/library/panic_unwind/src/lib.rs
+++ b/library/panic_unwind/src/lib.rs
@@ -49,7 +49,7 @@ cfg_if::cfg_if! {
     } else if #[cfg(any(
         all(target_family = "windows", target_env = "gnu"),
         target_os = "psp",
-        target_family = "unix",
+        all(target_family = "unix", not(target_os = "espidf")),
         all(target_vendor = "fortanix", target_env = "sgx"),
     ))] {
         // Rust runtime's startup objects depend on these symbols, so make them public.
@@ -62,6 +62,7 @@ cfg_if::cfg_if! {
         // - arch=wasm32
         // - os=none ("bare metal" targets)
         // - os=uefi
+        // - os=espidf
         // - nvptx64-nvidia-cuda
         // - arch=avr
         #[path = "dummy.rs"]

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -16,7 +16,7 @@ cfg-if = { version = "0.1.8", features = ['rustc-dep-of-std'] }
 panic_unwind = { path = "../panic_unwind", optional = true }
 panic_abort = { path = "../panic_abort" }
 core = { path = "../core" }
-libc = { version = "0.2.93", default-features = false, features = ['rustc-dep-of-std'] }
+libc = { git = "https://github.com/ivmarkov/libc.git", branch = "version_0.2.98", default-features = false, features = ['rustc-dep-of-std'] }
 compiler_builtins = { version = "0.1.39" }
 profiler_builtins = { path = "../profiler_builtins", optional = true }
 unwind = { path = "../unwind" }

--- a/library/std/build.rs
+++ b/library/std/build.rs
@@ -26,6 +26,7 @@ fn main() {
         || target.contains("vxworks")
         || target.contains("wasm32")
         || target.contains("asmjs")
+        || target.contains("espidf")
     {
         // These platforms don't have any special requirements.
     } else {

--- a/library/std/src/os/espidf/fs.rs
+++ b/library/std/src/os/espidf/fs.rs
@@ -1,0 +1,126 @@
+#![stable(feature = "metadata_ext", since = "1.1.0")]
+
+use crate::fs::Metadata;
+use crate::sys_common::AsInner;
+
+#[allow(deprecated)]
+use crate::os::espidf::raw;
+
+/// OS-specific extensions to [`fs::Metadata`].
+///
+/// [`fs::Metadata`]: crate::fs::Metadata
+#[stable(feature = "metadata_ext", since = "1.1.0")]
+pub trait MetadataExt {
+    #[stable(feature = "metadata_ext", since = "1.1.0")]
+    #[rustc_deprecated(
+        since = "1.8.0",
+        reason = "deprecated in favor of the accessor \
+                  methods of this trait"
+    )]
+    #[allow(deprecated)]
+    fn as_raw_stat(&self) -> &raw::stat;
+
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_dev(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_ino(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_mode(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_nlink(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_uid(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_gid(&self) -> u32;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_rdev(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_size(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_atime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_atime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_mtime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_mtime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_ctime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_ctime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_crtime(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_crtime_nsec(&self) -> i64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_blksize(&self) -> u64;
+    #[stable(feature = "metadata_ext2", since = "1.8.0")]
+    fn st_blocks(&self) -> u64;
+}
+
+#[stable(feature = "metadata_ext", since = "1.1.0")]
+impl MetadataExt for Metadata {
+    #[allow(deprecated)]
+    fn as_raw_stat(&self) -> &raw::stat {
+        unsafe { &*(self.as_inner().as_inner() as *const libc::stat as *const raw::stat) }
+    }
+    fn st_dev(&self) -> u64 {
+        self.as_inner().as_inner().st_dev as u64
+    }
+    fn st_ino(&self) -> u64 {
+        self.as_inner().as_inner().st_ino as u64
+    }
+    fn st_mode(&self) -> u32 {
+        self.as_inner().as_inner().st_mode as u32
+    }
+    fn st_nlink(&self) -> u64 {
+        self.as_inner().as_inner().st_nlink as u64
+    }
+    fn st_uid(&self) -> u32 {
+        self.as_inner().as_inner().st_uid as u32
+    }
+    fn st_gid(&self) -> u32 {
+        self.as_inner().as_inner().st_gid as u32
+    }
+    fn st_rdev(&self) -> u64 {
+        self.as_inner().as_inner().st_rdev as u64
+    }
+    fn st_size(&self) -> u64 {
+        self.as_inner().as_inner().st_size as u64
+    }
+    fn st_atime(&self) -> i64 {
+        self.as_inner().as_inner().st_atime as i64
+    }
+    fn st_atime_nsec(&self) -> i64 {
+        //self.as_inner().as_inner().st_atime_nsec as i64
+        0
+    }
+    fn st_mtime(&self) -> i64 {
+        self.as_inner().as_inner().st_mtime as i64
+    }
+    fn st_mtime_nsec(&self) -> i64 {
+        //self.as_inner().as_inner().st_mtime_nsec as i64
+        0
+    }
+    fn st_ctime(&self) -> i64 {
+        self.as_inner().as_inner().st_ctime as i64
+    }
+    fn st_ctime_nsec(&self) -> i64 {
+        //self.as_inner().as_inner().st_ctime_nsec as i64
+        0
+    }
+    fn st_crtime(&self) -> i64 {
+        //self.as_inner().as_inner().st_crtime as i64
+        0
+    }
+    fn st_crtime_nsec(&self) -> i64 {
+        //self.as_inner().as_inner().st_crtime_nsec as i64
+        0
+    }
+    fn st_blksize(&self) -> u64 {
+        self.as_inner().as_inner().st_blksize as u64
+    }
+    fn st_blocks(&self) -> u64 {
+        self.as_inner().as_inner().st_blocks as u64
+    }
+}

--- a/library/std/src/os/espidf/mod.rs
+++ b/library/std/src/os/espidf/mod.rs
@@ -1,0 +1,7 @@
+//! Definitions for the ESP-IDF framework.
+
+// TODO: Figure out if these can be proclaimed as "stable" and if yes, since what version
+#![stable(feature = "raw_ext", since = "1.1.0")]
+
+pub mod fs;
+pub mod raw;

--- a/library/std/src/os/espidf/raw.rs
+++ b/library/std/src/os/espidf/raw.rs
@@ -1,0 +1,74 @@
+//! Raw type definitions for the ESP-IDF framework.
+
+#![stable(feature = "raw_ext", since = "1.1.0")]
+#![allow(deprecated)]
+
+use crate::os::raw::c_long;
+use crate::os::unix::raw::{gid_t, uid_t};
+
+// Use the direct definition of usize, instead of uintptr_t like in libc
+#[stable(feature = "pthread_t", since = "1.8.0")]
+pub type pthread_t = libc::pthread_t;
+
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type blkcnt_t = libc::blkcnt_t;
+
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type blksize_t = libc::blksize_t;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type dev_t = libc::dev_t;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type ino_t = libc::ino_t;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type mode_t = libc::mode_t;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type nlink_t = libc::nlink_t;
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type off_t = libc::off_t;
+
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub type time_t = libc::time_t;
+
+#[repr(C)]
+#[derive(Clone)]
+#[stable(feature = "raw_ext", since = "1.1.0")]
+pub struct stat {
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_dev: dev_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_ino: ino_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_mode: mode_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_nlink: nlink_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_uid: uid_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_gid: gid_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_rdev: dev_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_size: off_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_atime: time_t,
+    // #[stable(feature = "raw_ext", since = "1.1.0")]
+    // pub st_atime_nsec: c_long,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_mtime: time_t,
+    // #[stable(feature = "raw_ext", since = "1.1.0")]
+    // pub st_mtime_nsec: c_long,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_ctime: time_t,
+    // #[stable(feature = "raw_ext", since = "1.1.0")]
+    // pub st_ctime_nsec: c_long,
+    // #[stable(feature = "raw_ext", since = "1.1.0")]
+    // pub st_crtime: time_t,
+    // #[stable(feature = "raw_ext", since = "1.1.0")]
+    // pub st_crtime_nsec: c_long,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_blksize: blksize_t,
+    #[stable(feature = "raw_ext", since = "1.1.0")]
+    pub st_blocks: blkcnt_t,
+    // #[stable(feature = "raw_ext", since = "1.1.0")]
+    // pub st_type: u32,
+}

--- a/library/std/src/os/mod.rs
+++ b/library/std/src/os/mod.rs
@@ -52,6 +52,8 @@ pub mod android;
 pub mod dragonfly;
 #[cfg(target_os = "emscripten")]
 pub mod emscripten;
+#[cfg(target_os = "espidf")]
+pub mod espidf;
 #[cfg(all(target_vendor = "fortanix", target_env = "sgx"))]
 pub mod fortanix_sgx;
 #[cfg(target_os = "freebsd")]

--- a/library/std/src/sys/common/alloc.rs
+++ b/library/std/src/sys/common/alloc.rs
@@ -14,7 +14,8 @@ use crate::ptr;
     target_arch = "asmjs",
     target_arch = "wasm32",
     target_arch = "hexagon",
-    target_arch = "riscv32"
+    target_arch = "riscv32",
+    target_arch = "xtensa"
 )))]
 pub const MIN_ALIGN: usize = 8;
 #[cfg(all(any(

--- a/library/std/src/sys/unix/condvar.rs
+++ b/library/std/src/sys/unix/condvar.rs
@@ -34,12 +34,23 @@ impl Condvar {
     ))]
     pub unsafe fn init(&mut self) {}
 
+    // NOTE: ESP-IDF's PTHREAD_COND_INITIALIZER support is not released yet
+    // So on that platform, init() should always be called
+    // Moreover, that platform does not have pthread_condattr_setclock support,
+    // hence that initialization is skipped
+    #[cfg(target_os = "espidf")]
+    pub unsafe fn init(&mut self) {
+        let r = libc::pthread_cond_init(self.inner.get(), crate::ptr::null());
+        assert_eq!(r, 0);
+    }
+
     #[cfg(not(any(
         target_os = "macos",
         target_os = "ios",
         target_os = "l4re",
         target_os = "android",
-        target_os = "redox"
+        target_os = "redox",
+        target_os = "espidf",
     )))]
     pub unsafe fn init(&mut self) {
         use crate::mem::MaybeUninit;
@@ -68,7 +79,7 @@ impl Condvar {
 
     #[inline]
     pub unsafe fn wait(&self, mutex: &Mutex) {
-        let r = libc::pthread_cond_wait(self.inner.get(), mutex::raw(mutex));
+        let r = libc::pthread_cond_wait(self.inner.get(), mutex::raw(mutex) as *mut _);
         debug_assert_eq!(r, 0);
     }
 
@@ -76,7 +87,12 @@ impl Condvar {
     // where we configure condition variable to use monotonic clock (instead of
     // default system clock). This approach avoids all problems that result
     // from changes made to the system time.
-    #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "android")))]
+    #[cfg(not(any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "android",
+        target_os = "espidf",
+    )))]
     pub unsafe fn wait_timeout(&self, mutex: &Mutex, dur: Duration) -> bool {
         use crate::mem;
 
@@ -103,7 +119,12 @@ impl Condvar {
     // This implementation is modeled after libcxx's condition_variable
     // https://github.com/llvm-mirror/libcxx/blob/release_35/src/condition_variable.cpp#L46
     // https://github.com/llvm-mirror/libcxx/blob/release_35/include/__mutex_base#L367
-    #[cfg(any(target_os = "macos", target_os = "ios", target_os = "android"))]
+    #[cfg(any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "android",
+        target_os = "espidf",
+    ))]
     pub unsafe fn wait_timeout(&self, mutex: &Mutex, mut dur: Duration) -> bool {
         use crate::ptr;
         use crate::time::Instant;
@@ -148,7 +169,8 @@ impl Condvar {
             .unwrap_or(TIMESPEC_MAX);
 
         // And wait!
-        let r = libc::pthread_cond_timedwait(self.inner.get(), mutex::raw(mutex), &timeout);
+        let r =
+            libc::pthread_cond_timedwait(self.inner.get(), mutex::raw(mutex) as *mut _, &timeout);
         debug_assert!(r == libc::ETIMEDOUT || r == 0);
 
         // ETIMEDOUT is not a totally reliable method of determining timeout due

--- a/library/std/src/sys/unix/env.rs
+++ b/library/std/src/sys/unix/env.rs
@@ -184,3 +184,14 @@ pub mod os {
     pub const EXE_SUFFIX: &str = "";
     pub const EXE_EXTENSION: &str = "";
 }
+
+#[cfg(target_os = "espidf")]
+pub mod os {
+    pub const FAMILY: &str = "unix";
+    pub const OS: &str = "espidf";
+    pub const DLL_PREFIX: &str = "lib";
+    pub const DLL_SUFFIX: &str = ".so";
+    pub const DLL_EXTENSION: &str = "so";
+    pub const EXE_SUFFIX: &str = "";
+    pub const EXE_EXTENSION: &str = "";
+}

--- a/library/std/src/sys/unix/ext/mod.rs
+++ b/library/std/src/sys/unix/ext/mod.rs
@@ -40,6 +40,8 @@ cfg_if::cfg_if! {
         use crate::os::dragonfly as platform;
         #[cfg(target_os = "emscripten")]
         use crate::os::emscripten as platform;
+        #[cfg(target_os = "espidf")]
+        use crate::os::espidf as platform;
         #[cfg(target_os = "freebsd")]
         use crate::os::freebsd as platform;
         #[cfg(target_os = "fuchsia")]

--- a/library/std/src/sys/unix/fs.rs
+++ b/library/std/src/sys/unix/fs.rs
@@ -297,7 +297,7 @@ impl FileAttr {
 
 #[cfg(not(target_os = "netbsd"))]
 impl FileAttr {
-    #[cfg(not(target_os = "vxworks"))]
+    #[cfg(all(not(target_os = "vxworks"), not(target_os = "espidf")))]
     pub fn modified(&self) -> io::Result<SystemTime> {
         Ok(SystemTime::from(libc::timespec {
             tv_sec: self.stat.st_mtime as libc::time_t,
@@ -305,7 +305,7 @@ impl FileAttr {
         }))
     }
 
-    #[cfg(target_os = "vxworks")]
+    #[cfg(any(target_os = "vxworks", target_os = "espidf"))]
     pub fn modified(&self) -> io::Result<SystemTime> {
         Ok(SystemTime::from(libc::timespec {
             tv_sec: self.stat.st_mtime as libc::time_t,
@@ -313,7 +313,7 @@ impl FileAttr {
         }))
     }
 
-    #[cfg(not(target_os = "vxworks"))]
+    #[cfg(all(not(target_os = "vxworks"), not(target_os = "espidf")))]
     pub fn accessed(&self) -> io::Result<SystemTime> {
         Ok(SystemTime::from(libc::timespec {
             tv_sec: self.stat.st_atime as libc::time_t,
@@ -321,7 +321,7 @@ impl FileAttr {
         }))
     }
 
-    #[cfg(target_os = "vxworks")]
+    #[cfg(any(target_os = "vxworks", target_os = "espidf"))]
     pub fn accessed(&self) -> io::Result<SystemTime> {
         Ok(SystemTime::from(libc::timespec {
             tv_sec: self.stat.st_atime as libc::time_t,
@@ -594,7 +594,8 @@ impl DirEntry {
         target_os = "l4re",
         target_os = "fuchsia",
         target_os = "redox",
-        target_os = "vxworks"
+        target_os = "vxworks",
+        target_os = "espidf"
     ))]
     pub fn ino(&self) -> u64 {
         self.entry.d_ino as u64
@@ -633,7 +634,8 @@ impl DirEntry {
         target_os = "emscripten",
         target_os = "l4re",
         target_os = "haiku",
-        target_os = "vxworks"
+        target_os = "vxworks",
+        target_os = "espidf"
     ))]
     fn name_bytes(&self) -> &[u8] {
         unsafe { CStr::from_ptr(self.entry.d_name.as_ptr()).to_bytes() }
@@ -1082,8 +1084,8 @@ pub fn link(original: &Path, link: &Path) -> io::Result<()> {
     let original = cstr(original)?;
     let link = cstr(link)?;
     cfg_if::cfg_if! {
-        if #[cfg(any(target_os = "vxworks", target_os = "redox", target_os = "android"))] {
-            // VxWorks, Redox, and old versions of Android lack `linkat`, so use
+        if #[cfg(any(target_os = "vxworks", target_os = "redox", target_os = "android", target_os = "espidf"))] {
+            // VxWorks, Redox, ESP-IDF, and old versions of Android lack `linkat`, so use
             // `link` instead. POSIX leaves it implementation-defined whether
             // `link` follows symlinks, so rely on the `symlink_hard_link` test
             // in library/std/src/fs/tests.rs to check the behavior.
@@ -1162,6 +1164,18 @@ fn open_from(from: &Path) -> io::Result<(crate::fs::File, crate::fs::Metadata)> 
     Ok((reader, metadata))
 }
 
+#[cfg(target_os = "espidf")]
+fn open_to_and_set_permissions(
+    to: &Path,
+    reader_metadata: crate::fs::Metadata,
+) -> io::Result<(crate::fs::File, crate::fs::Metadata)> {
+    use crate::fs::OpenOptions;
+    let writer = OpenOptions::new().open(to)?;
+    let writer_metadata = writer.metadata()?;
+    Ok((writer, writer_metadata))
+}
+
+#[cfg(not(target_os = "espidf"))]
 fn open_to_and_set_permissions(
     to: &Path,
     reader_metadata: crate::fs::Metadata,

--- a/library/std/src/sys/unix/mod.rs
+++ b/library/std/src/sys/unix/mod.rs
@@ -5,11 +5,13 @@ use crate::io::ErrorKind;
 pub use self::rand::hashmap_random_keys;
 pub use libc::strlen;
 
+#[cfg(not(target_os = "espidf"))]
 #[macro_use]
 pub mod weak;
 
 pub mod alloc;
 pub mod android;
+#[cfg_attr(target_os = "espidf", path = "../unsupported/args.rs")]
 pub mod args;
 #[path = "../unix/cmath.rs"]
 pub mod cmath;
@@ -28,6 +30,8 @@ pub mod memchr;
 pub mod mutex;
 #[cfg(not(target_os = "l4re"))]
 pub mod net;
+#[cfg(target_os = "espidf")]
+mod net_lwip;
 #[cfg(target_os = "l4re")]
 pub use self::l4re::net;
 pub mod os;
@@ -35,6 +39,7 @@ pub mod path;
 pub mod pipe;
 pub mod process;
 pub mod rand;
+#[cfg_attr(target_os = "espidf", path = "../wasm/rwlock_atomics.rs")]
 pub mod rwlock;
 pub mod stack_overflow;
 pub mod stdio;
@@ -45,6 +50,11 @@ pub mod time;
 
 pub use crate::sys_common::os_str_bytes as os_str;
 
+#[cfg(all(not(test), target_os = "espidf"))]
+pub fn init(argc: isize, argv: *const *const u8) {
+}
+
+#[cfg(all(not(test), not(target_os = "espidf")))]
 // SAFETY: must be called only once during runtime initialization.
 // NOTE: this is not guaranteed to run, for example when Rust code is called externally.
 pub unsafe fn init(argc: isize, argv: *const *const u8) {

--- a/library/std/src/sys/unix/mutex.rs
+++ b/library/std/src/sys/unix/mutex.rs
@@ -2,14 +2,33 @@ use crate::cell::UnsafeCell;
 use crate::mem::MaybeUninit;
 use crate::sys::cvt_nz;
 
+// The newlib definitions in libc for pthread_mutex_t and PTHREAD_MUTEX_INITIALIZER
+// are way off compared to what we have in ESP-IDF:
+// 1) ESP-IDF's pthread_mutex_t is only 4 bytes and not 40+ (because it is in fact a pointer to dynamically allocated structure)
+// 2) While the above is just a waste of space, ESP-IDF PTHREAD_MUTEX_INITIALIZER is the real issue:
+//    in libc it is defined as a series of 0s, while in ES-IDF it is equal to 0xffffffff
+#[cfg(target_os = "espidf")]
+pub type pthread_mutex_t = u32;
+#[cfg(target_os = "espidf")]
+pub type pthread_mutexattr_t = u64;
+#[cfg(target_os = "espidf")]
+const PTHREAD_MUTEX_INITIALIZER: pthread_mutex_t = 0xffffffff;
+
+#[cfg(not(target_os = "espidf"))]
+pub type pthread_mutex_t = libc::pthread_mutex_t;
+#[cfg(not(target_os = "espidf"))]
+pub type pthread_mutexattr_t = libc::pthread_mutexattr_t;
+#[cfg(not(target_os = "espidf"))]
+const PTHREAD_MUTEX_INITIALIZER: pthread_mutex_t = libc::PTHREAD_MUTEX_INITIALIZER;
+
 pub struct Mutex {
-    inner: UnsafeCell<libc::pthread_mutex_t>,
+    inner: UnsafeCell<pthread_mutex_t>,
 }
 
 pub type MovableMutex = Box<Mutex>;
 
 #[inline]
-pub unsafe fn raw(m: &Mutex) -> *mut libc::pthread_mutex_t {
+pub unsafe fn raw(m: &Mutex) -> *mut pthread_mutex_t {
     m.inner.get()
 }
 
@@ -23,7 +42,7 @@ impl Mutex {
         // initialization of potentially opaque OS data before it landed.
         // Be very careful using this newly constructed `Mutex`, reentrant
         // locking is undefined behavior until `init` is called!
-        Mutex { inner: UnsafeCell::new(libc::PTHREAD_MUTEX_INITIALIZER) }
+        Mutex { inner: UnsafeCell::new(PTHREAD_MUTEX_INITIALIZER) }
     }
     #[inline]
     pub unsafe fn init(&mut self) {
@@ -51,37 +70,41 @@ impl Mutex {
         // references, we instead create the mutex with type
         // PTHREAD_MUTEX_NORMAL which is guaranteed to deadlock if we try to
         // re-lock it from the same thread, thus avoiding undefined behavior.
-        let mut attr = MaybeUninit::<libc::pthread_mutexattr_t>::uninit();
-        cvt_nz(libc::pthread_mutexattr_init(attr.as_mut_ptr())).unwrap();
+        let mut attr = MaybeUninit::<pthread_mutexattr_t>::uninit();
+        cvt_nz(libc::pthread_mutexattr_init(attr.as_mut_ptr() as *mut _)).unwrap();
         let attr = PthreadMutexAttr(&mut attr);
-        cvt_nz(libc::pthread_mutexattr_settype(attr.0.as_mut_ptr(), libc::PTHREAD_MUTEX_NORMAL))
+        cvt_nz(libc::pthread_mutexattr_settype(
+            attr.0.as_mut_ptr() as *mut _,
+            libc::PTHREAD_MUTEX_NORMAL,
+        ))
+        .unwrap();
+        cvt_nz(libc::pthread_mutex_init(self.inner.get() as *mut _, attr.0.as_ptr() as *mut _))
             .unwrap();
-        cvt_nz(libc::pthread_mutex_init(self.inner.get(), attr.0.as_ptr())).unwrap();
     }
     #[inline]
     pub unsafe fn lock(&self) {
-        let r = libc::pthread_mutex_lock(self.inner.get());
+        let r = libc::pthread_mutex_lock(self.inner.get() as *mut _);
         debug_assert_eq!(r, 0);
     }
     #[inline]
     pub unsafe fn unlock(&self) {
-        let r = libc::pthread_mutex_unlock(self.inner.get());
+        let r = libc::pthread_mutex_unlock(self.inner.get() as *mut _);
         debug_assert_eq!(r, 0);
     }
     #[inline]
     pub unsafe fn try_lock(&self) -> bool {
-        libc::pthread_mutex_trylock(self.inner.get()) == 0
+        libc::pthread_mutex_trylock(self.inner.get() as *mut _) == 0
     }
     #[inline]
     #[cfg(not(target_os = "dragonfly"))]
     pub unsafe fn destroy(&self) {
-        let r = libc::pthread_mutex_destroy(self.inner.get());
+        let r = libc::pthread_mutex_destroy(self.inner.get() as *mut _);
         debug_assert_eq!(r, 0);
     }
     #[inline]
     #[cfg(target_os = "dragonfly")]
     pub unsafe fn destroy(&self) {
-        let r = libc::pthread_mutex_destroy(self.inner.get());
+        let r = libc::pthread_mutex_destroy(self.inner.get() as *mut _);
         // On DragonFly pthread_mutex_destroy() returns EINVAL if called on a
         // mutex that was just initialized with libc::PTHREAD_MUTEX_INITIALIZER.
         // Once it is used (locked/unlocked) or pthread_mutex_init() is called,
@@ -91,7 +114,7 @@ impl Mutex {
 }
 
 pub struct ReentrantMutex {
-    inner: UnsafeCell<libc::pthread_mutex_t>,
+    inner: UnsafeCell<pthread_mutex_t>,
 }
 
 unsafe impl Send for ReentrantMutex {}
@@ -99,45 +122,49 @@ unsafe impl Sync for ReentrantMutex {}
 
 impl ReentrantMutex {
     pub const unsafe fn uninitialized() -> ReentrantMutex {
-        ReentrantMutex { inner: UnsafeCell::new(libc::PTHREAD_MUTEX_INITIALIZER) }
+        ReentrantMutex { inner: UnsafeCell::new(PTHREAD_MUTEX_INITIALIZER) }
     }
 
     pub unsafe fn init(&self) {
-        let mut attr = MaybeUninit::<libc::pthread_mutexattr_t>::uninit();
-        cvt_nz(libc::pthread_mutexattr_init(attr.as_mut_ptr())).unwrap();
+        let mut attr = MaybeUninit::<pthread_mutexattr_t>::uninit();
+        cvt_nz(libc::pthread_mutexattr_init(attr.as_mut_ptr() as *mut _)).unwrap();
         let attr = PthreadMutexAttr(&mut attr);
-        cvt_nz(libc::pthread_mutexattr_settype(attr.0.as_mut_ptr(), libc::PTHREAD_MUTEX_RECURSIVE))
+        cvt_nz(libc::pthread_mutexattr_settype(
+            attr.0.as_mut_ptr() as *mut _,
+            libc::PTHREAD_MUTEX_RECURSIVE,
+        ))
+        .unwrap();
+        cvt_nz(libc::pthread_mutex_init(self.inner.get() as *mut _, attr.0.as_ptr() as *mut _))
             .unwrap();
-        cvt_nz(libc::pthread_mutex_init(self.inner.get(), attr.0.as_ptr())).unwrap();
     }
 
     pub unsafe fn lock(&self) {
-        let result = libc::pthread_mutex_lock(self.inner.get());
+        let result = libc::pthread_mutex_lock(self.inner.get() as *mut _);
         debug_assert_eq!(result, 0);
     }
 
     #[inline]
     pub unsafe fn try_lock(&self) -> bool {
-        libc::pthread_mutex_trylock(self.inner.get()) == 0
+        libc::pthread_mutex_trylock(self.inner.get() as *mut _) == 0
     }
 
     pub unsafe fn unlock(&self) {
-        let result = libc::pthread_mutex_unlock(self.inner.get());
+        let result = libc::pthread_mutex_unlock(self.inner.get() as *mut _);
         debug_assert_eq!(result, 0);
     }
 
     pub unsafe fn destroy(&self) {
-        let result = libc::pthread_mutex_destroy(self.inner.get());
+        let result = libc::pthread_mutex_destroy(self.inner.get() as *mut _);
         debug_assert_eq!(result, 0);
     }
 }
 
-struct PthreadMutexAttr<'a>(&'a mut MaybeUninit<libc::pthread_mutexattr_t>);
+struct PthreadMutexAttr<'a>(&'a mut MaybeUninit<pthread_mutexattr_t>);
 
 impl Drop for PthreadMutexAttr<'_> {
     fn drop(&mut self) {
         unsafe {
-            let result = libc::pthread_mutexattr_destroy(self.0.as_mut_ptr());
+            let result = libc::pthread_mutexattr_destroy(self.0.as_mut_ptr() as *mut _);
             debug_assert_eq!(result, 0);
         }
     }

--- a/library/std/src/sys/unix/net.rs
+++ b/library/std/src/sys/unix/net.rs
@@ -9,7 +9,7 @@ use crate::sys_common::net::{getsockopt, setsockopt, sockaddr_to_addr};
 use crate::sys_common::{AsInner, FromInner, IntoInner};
 use crate::time::{Duration, Instant};
 
-use libc::{c_int, c_void, size_t, sockaddr, socklen_t, EAI_SYSTEM, MSG_PEEK};
+use libc::{c_int, c_void, size_t, sockaddr, socklen_t, MSG_PEEK};
 
 pub use crate::sys::{cvt, cvt_r};
 
@@ -30,13 +30,19 @@ pub fn cvt_gai(err: c_int) -> io::Result<()> {
     // We may need to trigger a glibc workaround. See on_resolver_failure() for details.
     on_resolver_failure();
 
-    if err == EAI_SYSTEM {
+    #[cfg(not(target_os = "espidf"))]
+    if err == libc::EAI_SYSTEM {
         return Err(io::Error::last_os_error());
     }
 
+    #[cfg(not(target_os = "espidf"))]
     let detail = unsafe {
         str::from_utf8(CStr::from_ptr(libc::gai_strerror(err)).to_bytes()).unwrap().to_owned()
     };
+
+    #[cfg(target_os = "espidf")]
+    let detail = "";
+
     Err(io::Error::new(
         io::ErrorKind::Other,
         &format!("failed to lookup address information: {}", detail)[..],

--- a/library/std/src/sys/unix/net_lwip.rs
+++ b/library/std/src/sys/unix/net_lwip.rs
@@ -1,0 +1,304 @@
+// A set of definitions useful for bare metal platforms, where the LwIP stack is compiled with the "lwip_"-prefixed function variants
+// The ESP-IDF SDK of Espressif is one such example
+
+use libc::*;
+
+extern "C" {
+    fn lwip_accept(
+        s: libc::c_int,
+        addr: *mut libc::sockaddr,
+        addrlen: *mut libc::socklen_t,
+    ) -> libc::c_int;
+    fn lwip_bind(
+        s: libc::c_int,
+        name: *const libc::sockaddr,
+        namelen: libc::socklen_t,
+    ) -> libc::c_int;
+    fn lwip_shutdown(s: libc::c_int, how: libc::c_int) -> libc::c_int;
+
+    fn lwip_getpeername(
+        s: libc::c_int,
+        name: *const libc::sockaddr,
+        namelen: libc::socklen_t,
+    ) -> libc::c_int;
+    fn lwip_getsockname(
+        s: libc::c_int,
+        name: *const libc::sockaddr,
+        namelen: libc::socklen_t,
+    ) -> libc::c_int;
+
+    fn lwip_setsockopt(
+        s: libc::c_int,
+        level: libc::c_int,
+        optname: libc::c_int,
+        opval: *const libc::c_void,
+        optlen: libc::socklen_t,
+    ) -> libc::c_int;
+    fn lwip_getsockopt(
+        s: libc::c_int,
+        level: libc::c_int,
+        optname: libc::c_int,
+        opval: *mut libc::c_void,
+        optlen: *mut libc::socklen_t,
+    ) -> libc::c_int;
+
+    fn lwip_close(s: libc::c_int) -> libc::c_int;
+
+    fn lwip_connect(
+        s: libc::c_int,
+        name: *const libc::sockaddr,
+        namelen: libc::socklen_t,
+    ) -> libc::c_int;
+    fn lwip_listen(s: libc::c_int, backlog: libc::c_int) -> libc::c_int;
+
+    fn lwip_recvmsg(
+        sockfd: libc::c_int,
+        msg: *mut libc::msghdr,
+        flags: libc::c_int,
+    ) -> libc::size_t;
+    fn lwip_recv(
+        s: libc::c_int,
+        mem: *mut libc::c_void,
+        len: libc::size_t,
+        flags: libc::c_int,
+    ) -> libc::size_t;
+    fn lwip_recvfrom(
+        s: libc::c_int,
+        mem: *mut libc::c_void,
+        len: libc::size_t,
+        flags: libc::c_int,
+        from: *mut libc::sockaddr,
+        fromlen: *mut libc::socklen_t,
+    ) -> libc::size_t;
+
+    fn lwip_send(
+        s: libc::c_int,
+        dataptr: *const libc::c_void,
+        size: libc::size_t,
+        flags: libc::c_int,
+    ) -> libc::size_t;
+    fn lwip_sendmsg(
+        s: libc::c_int,
+        message: *const libc::msghdr,
+        flags: libc::c_int,
+    ) -> libc::size_t;
+    fn lwip_sendto(
+        s: libc::c_int,
+        dataptr: *const libc::c_void,
+        size: libc::size_t,
+        flags: libc::c_int,
+        to: *const libc::sockaddr,
+        tolen: libc::socklen_t,
+    ) -> libc::size_t;
+
+    fn lwip_socket(domain: libc::c_int, typest: libc::c_int, protocol: libc::c_int) -> libc::c_int;
+    fn lwip_select(
+        maxfdp1: libc::c_int,
+        readset: *mut libc::fd_set,
+        writeset: *mut libc::fd_set,
+        exceptset: *mut libc::fd_set,
+        timeout: *mut libc::timeval,
+    ) -> libc::c_int;
+    fn lwip_ioctl(s: libc::c_int, cmd: libc::c_long, argp: *mut libc::c_void) -> libc::c_int;
+
+    fn lwip_gethostbyname_r(
+        name: *const libc::c_char,
+        ret: *mut libc::hostent,
+        buf: *mut libc::c_char,
+        buflen: libc::size_t,
+        result: *mut *mut libc::hostent,
+        h_errnop: *mut libc::c_int,
+    ) -> libc::c_int;
+    fn lwip_gethostbyname(name: *const libc::c_char) -> *mut libc::hostent;
+
+    fn lwip_freeaddrinfo(ai: *mut libc::addrinfo) -> libc::c_void;
+    fn lwip_getaddrinfo(
+        nodename: *const libc::c_char,
+        servname: *const libc::c_char,
+        hints: *const libc::addrinfo,
+        res: *mut *mut libc::addrinfo,
+    ) -> libc::c_int;
+}
+
+#[no_mangle]
+pub extern "C" fn accept(
+    s: libc::c_int,
+    addr: *mut libc::sockaddr,
+    addrlen: *mut libc::socklen_t,
+) -> libc::c_int {
+    unsafe { lwip_accept(s, addr, addrlen) }
+}
+#[no_mangle]
+pub extern "C" fn bind(
+    s: libc::c_int,
+    name: *const libc::sockaddr,
+    namelen: libc::socklen_t,
+) -> libc::c_int {
+    unsafe { lwip_bind(s, name, namelen) }
+}
+#[no_mangle]
+pub extern "C" fn shutdown(s: libc::c_int, how: libc::c_int) -> libc::c_int {
+    unsafe { lwip_shutdown(s, how) }
+}
+
+#[no_mangle]
+pub extern "C" fn getpeername(
+    s: libc::c_int,
+    name: *const libc::sockaddr,
+    namelen: libc::socklen_t,
+) -> libc::c_int {
+    unsafe { lwip_getpeername(s, name, namelen) }
+}
+#[no_mangle]
+pub extern "C" fn getsockname(
+    s: libc::c_int,
+    name: *const libc::sockaddr,
+    namelen: libc::socklen_t,
+) -> libc::c_int {
+    unsafe { lwip_getsockname(s, name, namelen) }
+}
+
+#[no_mangle]
+pub extern "C" fn setsockopt(
+    s: libc::c_int,
+    level: libc::c_int,
+    optname: libc::c_int,
+    opval: *const libc::c_void,
+    optlen: libc::socklen_t,
+) -> libc::c_int {
+    unsafe { lwip_setsockopt(s, level, optname, opval, optlen) }
+}
+#[no_mangle]
+pub extern "C" fn getsockopt(
+    s: libc::c_int,
+    level: libc::c_int,
+    optname: libc::c_int,
+    opval: *mut libc::c_void,
+    optlen: *mut libc::socklen_t,
+) -> libc::c_int {
+    unsafe { lwip_getsockopt(s, level, optname, opval, optlen) }
+}
+
+#[no_mangle]
+pub extern "C" fn closesocket(s: libc::c_int) -> libc::c_int {
+    unsafe { lwip_close(s) }
+}
+
+#[no_mangle]
+pub extern "C" fn connect(
+    s: libc::c_int,
+    name: *const libc::sockaddr,
+    namelen: libc::socklen_t,
+) -> libc::c_int {
+    unsafe { lwip_connect(s, name, namelen) }
+}
+#[no_mangle]
+pub extern "C" fn listen(s: libc::c_int, backlog: libc::c_int) -> libc::c_int {
+    unsafe { lwip_listen(s, backlog) }
+}
+
+#[no_mangle]
+pub extern "C" fn recvmsg(
+    sockfd: libc::c_int,
+    msg: *mut libc::msghdr,
+    flags: libc::c_int,
+) -> libc::size_t {
+    unsafe { lwip_recvmsg(sockfd, msg, flags) }
+}
+#[no_mangle]
+pub extern "C" fn recv(
+    s: libc::c_int,
+    mem: *mut libc::c_void,
+    len: libc::size_t,
+    flags: libc::c_int,
+) -> libc::size_t {
+    unsafe { lwip_recv(s, mem, len, flags) }
+}
+#[no_mangle]
+pub extern "C" fn recvfrom(
+    s: libc::c_int,
+    mem: *mut libc::c_void,
+    len: libc::size_t,
+    flags: libc::c_int,
+    from: *mut libc::sockaddr,
+    fromlen: *mut libc::socklen_t,
+) -> libc::size_t {
+    unsafe { lwip_recvfrom(s, mem, len, flags, from, fromlen) }
+}
+
+#[no_mangle]
+pub extern "C" fn send(
+    s: libc::c_int,
+    dataptr: *const libc::c_void,
+    size: libc::size_t,
+    flags: libc::c_int,
+) -> libc::size_t {
+    unsafe { lwip_send(s, dataptr, size, flags) }
+}
+#[no_mangle]
+pub extern "C" fn sendmsg(
+    s: libc::c_int,
+    message: *const libc::msghdr,
+    flags: libc::c_int,
+) -> libc::size_t {
+    unsafe { lwip_sendmsg(s, message, flags) }
+}
+#[no_mangle]
+pub extern "C" fn sendto(
+    s: libc::c_int,
+    dataptr: *const libc::c_void,
+    size: libc::size_t,
+    flags: libc::c_int,
+    to: *const libc::sockaddr,
+    tolen: libc::socklen_t,
+) -> libc::size_t {
+    unsafe { lwip_sendto(s, dataptr, size, flags, to, tolen) }
+}
+
+#[no_mangle]
+pub extern "C" fn socket(
+    domain: libc::c_int,
+    typest: libc::c_int,
+    protocol: libc::c_int,
+) -> libc::c_int {
+    unsafe { lwip_socket(domain, typest, protocol) }
+}
+// Defined by ESP-IDF #[no_mangle] pub extern "C" fn select(maxfdp1: libc::c_int, readset: *mut libc::fd_set, writeset: *mut libc::fd_set, exceptset: *mut libc::fd_set, timeout: *mut libc::timeval) -> libc::c_int {unsafe {lwip_select(maxfdp1, readset, writeset, exceptset, timeout)}}
+#[no_mangle]
+pub extern "C" fn ioctlsocket(
+    s: libc::c_int,
+    cmd: libc::c_long,
+    argp: *mut libc::c_void,
+) -> libc::c_int {
+    unsafe { lwip_ioctl(s, cmd, argp) }
+}
+
+#[no_mangle]
+pub extern "C" fn gethostbyname_r(
+    name: *const libc::c_char,
+    ret: *mut libc::hostent,
+    buf: *mut libc::c_char,
+    buflen: libc::size_t,
+    result: *mut *mut libc::hostent,
+    h_errnop: *mut libc::c_int,
+) -> libc::c_int {
+    unsafe { lwip_gethostbyname_r(name, ret, buf, buflen, result, h_errnop) }
+}
+#[no_mangle]
+pub extern "C" fn gethostbyname(name: *const libc::c_char) -> *mut libc::hostent {
+    unsafe { lwip_gethostbyname(name) }
+}
+
+#[no_mangle]
+pub extern "C" fn freeaddrinfo(ai: *mut libc::addrinfo) -> libc::c_void {
+    unsafe { lwip_freeaddrinfo(ai) }
+}
+#[no_mangle]
+pub extern "C" fn getaddrinfo(
+    nodename: *const libc::c_char,
+    servname: *const libc::c_char,
+    hints: *const libc::addrinfo,
+    res: *mut *mut libc::addrinfo,
+) -> libc::c_int {
+    unsafe { lwip_getaddrinfo(nodename, servname, hints, res) }
+}

--- a/library/std/src/sys/unix/os.rs
+++ b/library/std/src/sys/unix/os.rs
@@ -20,11 +20,18 @@ use crate::slice;
 use crate::str;
 use crate::sys::cvt;
 use crate::sys::fd;
-use crate::sys::rwlock::{RWLockReadGuard, StaticRWLock};
+#[cfg(not(target_os = "espidf"))]
+use crate::sys::rwlock::{RWLockReadGuard, RWLockWriteGuard, StaticRWLock};
+#[cfg(target_os = "espidf")] // No RW locks in ESP-IDF yet
 use crate::sys_common::mutex::{StaticMutex, StaticMutexGuard};
 use crate::vec;
 
 use libc::{c_char, c_int, c_void};
+
+#[cfg(target_os = "espidf")]
+#[path = "../unsupported/common.rs"]
+#[deny(unsafe_op_in_unsafe_fn)]
+mod unsupported;
 
 const TMPBUF_SZ: usize = 128;
 
@@ -126,6 +133,12 @@ pub fn error_string(errno: i32) -> String {
     }
 }
 
+#[cfg(target_os = "espidf")]
+pub fn getcwd() -> io::Result<PathBuf> {
+    Ok(PathBuf::from("/"))
+}
+
+#[cfg(not(target_os = "espidf"))]
 pub fn getcwd() -> io::Result<PathBuf> {
     let mut buf = Vec::with_capacity(512);
     loop {
@@ -152,6 +165,12 @@ pub fn getcwd() -> io::Result<PathBuf> {
     }
 }
 
+#[cfg(target_os = "espidf")]
+pub fn chdir(p: &path::Path) -> io::Result<()> {
+    Err(unsupported::unsupported_err())
+}
+
+#[cfg(not(target_os = "espidf"))]
 pub fn chdir(p: &path::Path) -> io::Result<()> {
     let p: &OsStr = p.as_ref();
     let p = CString::new(p.as_bytes())?;
@@ -457,6 +476,11 @@ pub fn current_exe() -> io::Result<PathBuf> {
     path.canonicalize()
 }
 
+#[cfg(target_os = "espidf")]
+pub fn current_exe() -> io::Result<PathBuf> {
+    unsupported::unsupported()
+}
+
 pub struct Env {
     iter: vec::IntoIter<(OsString, OsString)>,
 }
@@ -490,10 +514,30 @@ pub unsafe fn environ() -> *mut *const *const c_char {
     ptr::addr_of_mut!(environ)
 }
 
+#[cfg(not(target_os = "espidf"))]
 static ENV_LOCK: StaticRWLock = StaticRWLock::new();
 
+#[cfg(not(target_os = "espidf"))]
+pub fn env_write_lock() -> RWLockWriteGuard {
+    ENV_LOCK.write_with_guard()
+}
+
+#[cfg(not(target_os = "espidf"))]
 pub fn env_read_lock() -> RWLockReadGuard {
     ENV_LOCK.read_with_guard()
+}
+
+#[cfg(target_os = "espidf")]
+static ENV_LOCK: StaticMutex = StaticMutex::new();
+
+#[cfg(target_os = "espidf")]
+pub unsafe fn env_write_lock() -> StaticMutexGuard {
+    ENV_LOCK.lock()
+}
+
+#[cfg(target_os = "espidf")]
+pub unsafe fn env_read_lock() -> StaticMutexGuard {
+    ENV_LOCK.lock()
 }
 
 /// Returns a vector of (variable, value) byte-vector pairs for all the
@@ -553,7 +597,7 @@ pub fn setenv(k: &OsStr, v: &OsStr) -> io::Result<()> {
     let v = CString::new(v.as_bytes())?;
 
     unsafe {
-        let _guard = ENV_LOCK.write_with_guard();
+        let _guard = env_write_lock();
         cvt(libc::setenv(k.as_ptr(), v.as_ptr(), 1)).map(drop)
     }
 }
@@ -562,13 +606,19 @@ pub fn unsetenv(n: &OsStr) -> io::Result<()> {
     let nbuf = CString::new(n.as_bytes())?;
 
     unsafe {
-        let _guard = ENV_LOCK.write_with_guard();
+        let _guard = env_write_lock();
         cvt(libc::unsetenv(nbuf.as_ptr())).map(drop)
     }
 }
 
+#[cfg(not(target_os = "espidf"))]
 pub fn page_size() -> usize {
     unsafe { libc::sysconf(libc::_SC_PAGESIZE) as usize }
+}
+
+#[cfg(target_os = "espidf")]
+pub fn page_size() -> usize {
+    32
 }
 
 pub fn temp_dir() -> PathBuf {
@@ -585,6 +635,7 @@ pub fn home_dir() -> Option<PathBuf> {
     return crate::env::var_os("HOME").or_else(|| unsafe { fallback() }).map(PathBuf::from);
 
     #[cfg(any(
+        target_os = "espidf",
         target_os = "android",
         target_os = "ios",
         target_os = "emscripten",
@@ -595,6 +646,7 @@ pub fn home_dir() -> Option<PathBuf> {
         None
     }
     #[cfg(not(any(
+        target_os = "espidf",
         target_os = "android",
         target_os = "ios",
         target_os = "emscripten",

--- a/library/std/src/sys/unix/process/mod.rs
+++ b/library/std/src/sys/unix/process/mod.rs
@@ -13,6 +13,9 @@ cfg_if::cfg_if! {
     } else if #[cfg(target_os = "vxworks")] {
         #[path = "process_vxworks.rs"]
         mod process_inner;
+    } else if #[cfg(target_os = "espidf")] {
+        #[path = "process_none.rs"]
+        mod process_inner;
     } else {
         #[path = "process_unix.rs"]
         mod process_inner;

--- a/library/std/src/sys/unix/process/process_none.rs
+++ b/library/std/src/sys/unix/process/process_none.rs
@@ -1,0 +1,105 @@
+use crate::fmt;
+use crate::io;
+use crate::sys::pipe::AnonPipe;
+
+use crate::sys;
+use crate::sys::cvt;
+use crate::sys::process::process_common::*;
+
+use crate::io as std_io;
+
+use libc::{c_int, pid_t};
+
+#[path = "../../unsupported/common.rs"]
+#[deny(unsafe_op_in_unsafe_fn)]
+mod unsupported;
+
+////////////////////////////////////////////////////////////////////////////////
+// Command
+////////////////////////////////////////////////////////////////////////////////
+
+impl Command {
+    pub fn spawn(
+        &mut self,
+        default: Stdio,
+        needs_stdin: bool,
+    ) -> io::Result<(Process, StdioPipes)> {
+        unsupported::unsupported()
+    }
+
+    pub fn exec(&mut self, default: Stdio) -> io::Error {
+        unsupported::unsupported_err()
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Processes
+////////////////////////////////////////////////////////////////////////////////
+
+pub struct Process {
+    handle: pid_t,
+}
+
+impl Process {
+    pub fn id(&self) -> u32 {
+        0
+    }
+
+    pub fn kill(&mut self) -> io::Result<()> {
+        unsupported::unsupported()
+    }
+
+    pub fn wait(&mut self) -> io::Result<ExitStatus> {
+        unsupported::unsupported()
+    }
+
+    pub fn try_wait(&mut self) -> io::Result<Option<ExitStatus>> {
+        unsupported::unsupported()
+    }
+}
+
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
+pub struct ExitStatus(i32);
+
+impl ExitStatus {
+    pub fn success(&self) -> bool {
+        self.code() == Some(0)
+    }
+
+    pub fn code(&self) -> Option<i32> {
+        None
+    }
+
+    pub fn signal(&self) -> Option<i32> {
+        None
+    }
+
+    pub fn core_dumped(&self) -> bool {
+        false
+    }
+
+    pub fn stopped_signal(&self) -> Option<i32> {
+        None
+    }
+
+    pub fn continued(&self) -> bool {
+        false
+    }
+
+    pub fn into_raw(&self) -> c_int {
+        0
+    }
+}
+
+/// Converts a raw `c_int` to a type-safe `ExitStatus` by wrapping it without copying.
+impl From<c_int> for ExitStatus {
+    fn from(a: c_int) -> ExitStatus {
+        ExitStatus(a as i32)
+    }
+}
+
+impl fmt::Display for ExitStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "exit code: {}", self.0)
+    }
+}

--- a/library/std/src/sys/unix/rand.rs
+++ b/library/std/src/sys/unix/rand.rs
@@ -41,7 +41,20 @@ mod imp {
         unsafe { getrandom(buf.as_mut_ptr().cast(), buf.len(), libc::GRND_NONBLOCK) }
     }
 
-    #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    #[cfg(target_os = "espidf")]
+    fn getrandom_fill_bytes(buf: &mut [u8]) -> bool {
+        extern "C" {
+            fn esp_fill_random(buf: *mut libc::c_void, len: libc::size_t) -> libc::c_void;
+        }
+
+        unsafe {
+            esp_fill_random(buf.as_mut_ptr() as *mut libc::c_void, buf.len());
+        }
+
+        true // TODO: Return false if ESP32's WiFi or Bluetooth is not initialized
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "espidf")))]
     fn getrandom_fill_bytes(_buf: &mut [u8]) -> bool {
         false
     }

--- a/library/std/src/sys/unix/thread.rs
+++ b/library/std/src/sys/unix/thread.rs
@@ -6,12 +6,14 @@ use crate::ptr;
 use crate::sys::{os, stack_overflow};
 use crate::time::Duration;
 
-#[cfg(not(any(target_os = "l4re", target_os = "vxworks")))]
+#[cfg(not(any(target_os = "l4re", target_os = "vxworks", target_os = "espidf")))]
 pub const DEFAULT_MIN_STACK_SIZE: usize = 2 * 1024 * 1024;
 #[cfg(target_os = "l4re")]
 pub const DEFAULT_MIN_STACK_SIZE: usize = 1024 * 1024;
 #[cfg(target_os = "vxworks")]
 pub const DEFAULT_MIN_STACK_SIZE: usize = 256 * 1024;
+#[cfg(target_os = "espidf")]
+pub const DEFAULT_MIN_STACK_SIZE: usize = 5 * 1024;
 
 pub struct Thread {
     id: libc::pthread_t,
@@ -32,22 +34,51 @@ impl Thread {
 
         let stack_size = cmp::max(stack, min_stack_size(&attr));
 
-        match libc::pthread_attr_setstacksize(&mut attr, stack_size) {
-            0 => {}
-            n => {
-                assert_eq!(n, libc::EINVAL);
-                // EINVAL means |stack_size| is either too small or not a
-                // multiple of the system page size.  Because it's definitely
-                // >= PTHREAD_STACK_MIN, it must be an alignment issue.
-                // Round up to the nearest page and try again.
-                let page_size = os::page_size();
-                let stack_size =
-                    (stack_size + page_size - 1) & (-(page_size as isize - 1) as usize - 1);
-                assert_eq!(libc::pthread_attr_setstacksize(&mut attr, stack_size), 0);
-            }
-        };
+        let stack_size_res = libc::pthread_attr_setstacksize(&mut attr, stack_size);
 
-        let ret = libc::pthread_create(&mut native, &attr, thread_start, p as *mut _);
+        if cfg!(target_os = "espidf") {
+            assert_eq!(stack_size_res, 0);
+        } else {
+            match stack_size_res {
+                0 => {}
+                n => {
+                    #[cfg(not(target_os = "espidf"))]
+                    use os::page_size;
+
+                    #[cfg(target_os = "espidf")]
+                    fn page_size() -> usize {
+                        unreachable!()
+                    }
+
+                    assert_eq!(n, libc::EINVAL);
+                    // EINVAL means |stack_size| is either too small or not a
+                    // multiple of the system page size.  Because it's definitely
+                    // >= PTHREAD_STACK_MIN, it must be an alignment issue.
+                    // Round up to the nearest page and try again.
+                    let page_size = page_size();
+                    let stack_size =
+                        (stack_size + page_size - 1) & (-(page_size as isize - 1) as usize - 1);
+                    assert_eq!(libc::pthread_attr_setstacksize(&mut attr, stack_size), 0);
+                }
+            };
+        }
+
+        // This hack is necessary because currently libc does not expose the
+        // pthread_create symbol under newlib
+        // TODO: File a pull request against libc
+        #[cfg(target_os = "espidf")]
+        extern "C" {
+            fn pthread_create(
+                native: *mut libc::pthread_t,
+                attr: *const libc::pthread_attr_t,
+                f: extern "C" fn(_: *mut libc::c_void) -> *mut libc::c_void,
+                value: *mut libc::c_void,
+            ) -> libc::c_int;
+        }
+        #[cfg(not(target_os = "espidf"))]
+        use libc::pthread_create;
+
+        let ret = pthread_create(&mut native, &attr, thread_start, p as *mut _);
         // Note: if the thread creation fails and this assert fails, then p will
         // be leaked. However, an alternative design could cause double-free
         // which is clearly worse.
@@ -147,6 +178,7 @@ impl Thread {
         // FIXME: determine whether Fuchsia has a way to set a thread name.
     }
 
+    #[cfg(not(target_os = "espidf"))]
     pub fn sleep(dur: Duration) {
         let mut secs = dur.as_secs();
         let mut nsecs = dur.subsec_nanos() as _;
@@ -168,6 +200,19 @@ impl Thread {
                 } else {
                     nsecs = 0;
                 }
+            }
+        }
+    }
+
+    #[cfg(target_os = "espidf")]
+    pub fn sleep(dur: Duration) {
+        let mut micros = dur.as_micros();
+        unsafe {
+            while micros > 0 {
+                let st = if micros > u32::MAX as u128 { u32::MAX } else { micros as u32 };
+                libc::usleep(st);
+
+                micros -= st as u128;
             }
         }
     }
@@ -471,7 +516,7 @@ fn min_stack_size(attr: *const libc::pthread_attr_t) -> usize {
 
 // No point in looking up __pthread_get_minstack() on non-glibc
 // platforms.
-#[cfg(all(not(target_os = "linux"), not(target_os = "netbsd")))]
+#[cfg(all(not(target_os = "linux"), not(target_os = "netbsd"), not(target_os = "espidf")))]
 fn min_stack_size(_: *const libc::pthread_attr_t) -> usize {
     libc::PTHREAD_STACK_MIN
 }
@@ -479,4 +524,9 @@ fn min_stack_size(_: *const libc::pthread_attr_t) -> usize {
 #[cfg(target_os = "netbsd")]
 fn min_stack_size(_: *const libc::pthread_attr_t) -> usize {
     2048 // just a guess
+}
+
+#[cfg(target_os = "espidf")]
+fn min_stack_size(_: *const libc::pthread_attr_t) -> usize {
+    512 // just a guess
 }

--- a/library/std/src/sys/unix/time.rs
+++ b/library/std/src/sys/unix/time.rs
@@ -361,9 +361,9 @@ mod inner {
         }
     }
 
-    #[cfg(not(target_os = "dragonfly"))]
+    #[cfg(not(any(target_os = "dragonfly", target_os = "espidf")))]
     pub type clock_t = libc::c_int;
-    #[cfg(target_os = "dragonfly")]
+    #[cfg(any(target_os = "dragonfly", target_os = "espidf"))]
     pub type clock_t = libc::c_ulong;
 
     fn now(clock: clock_t) -> Timespec {

--- a/library/std/src/sys/unsupported/args.rs
+++ b/library/std/src/sys/unsupported/args.rs
@@ -34,3 +34,6 @@ impl DoubleEndedIterator for Args {
         None
     }
 }
+
+/// One-time global cleanup.
+pub unsafe fn cleanup() {}

--- a/library/std/src/sys/wasm/rwlock_atomics.rs
+++ b/library/std/src/sys/wasm/rwlock_atomics.rs
@@ -4,7 +4,8 @@ use crate::sys::mutex::Mutex;
 
 pub struct RWLock {
     lock: Mutex,
-    cond: Condvar,
+    cond: UnsafeCell<Condvar>,
+    initialized: UnsafeCell<bool>,
     state: UnsafeCell<State>,
 }
 
@@ -26,15 +27,34 @@ unsafe impl Sync for RWLock {}
 // the future.
 
 impl RWLock {
+    #[cfg(target_os = "espidf")]
     pub const fn new() -> RWLock {
-        RWLock { lock: Mutex::new(), cond: Condvar::new(), state: UnsafeCell::new(State::Unlocked) }
+        // NOTE: ESP-IDF's PTHREAD_COND_INITIALIZER support is not released yet
+        // So on that platform we need to manually initialize
+        RWLock {
+            lock: Mutex::new(),
+            cond: UnsafeCell::new(Condvar::new()),
+            initialized: UnsafeCell::new(false),
+            state: UnsafeCell::new(State::Unlocked),
+        }
+    }
+
+    #[cfg(not(target_os = "espidf"))]
+    pub const fn new() -> RWLock {
+        RWLock {
+            lock: Mutex::new(),
+            cond: UnsafeCell::new(Condvar::new()),
+            initialized: UnsafeCell::new(true),
+            state: UnsafeCell::new(State::Unlocked),
+        }
     }
 
     #[inline]
     pub unsafe fn read(&self) {
         self.lock.lock();
+        self.initialize();
         while !(*self.state.get()).inc_readers() {
-            self.cond.wait(&self.lock);
+            (*self.cond.get()).wait(&self.lock);
         }
         self.lock.unlock();
     }
@@ -50,8 +70,9 @@ impl RWLock {
     #[inline]
     pub unsafe fn write(&self) {
         self.lock.lock();
+        self.initialize();
         while !(*self.state.get()).inc_writers() {
-            self.cond.wait(&self.lock);
+            (*self.cond.get()).wait(&self.lock);
         }
         self.lock.unlock();
     }
@@ -67,27 +88,42 @@ impl RWLock {
     #[inline]
     pub unsafe fn read_unlock(&self) {
         self.lock.lock();
+        self.initialize();
         let notify = (*self.state.get()).dec_readers();
         self.lock.unlock();
         if notify {
             // FIXME: should only wake up one of these some of the time
-            self.cond.notify_all();
+            (*self.cond.get()).notify_all();
         }
     }
 
     #[inline]
     pub unsafe fn write_unlock(&self) {
         self.lock.lock();
+        self.initialize();
         (*self.state.get()).dec_writers();
         self.lock.unlock();
         // FIXME: should only wake up one of these some of the time
-        self.cond.notify_all();
+        (*self.cond.get()).notify_all();
     }
 
     #[inline]
     pub unsafe fn destroy(&self) {
+        self.lock.lock();
+        if (*self.initialized.get()) {
+            (*self.cond.get()).destroy();
+            *self.initialized.get() = false;
+        }
+        self.lock.unlock();
         self.lock.destroy();
-        self.cond.destroy();
+    }
+
+    #[inline]
+    unsafe fn initialize(&self) {
+        if (!*self.initialized.get()) {
+            (*self.cond.get()).init();
+            *self.initialized.get() = true;
+        }
     }
 }
 

--- a/library/std/src/sys_common/io.rs
+++ b/library/std/src/sys_common/io.rs
@@ -1,4 +1,5 @@
-pub const DEFAULT_BUF_SIZE: usize = 8 * 1024;
+// Bare metal platforms usually have very small amounts of RAM (in the order of hundreds of KB)
+pub const DEFAULT_BUF_SIZE: usize = if cfg!(target_os = "espidf") { 512 } else { 8 * 1024 };
 
 #[cfg(test)]
 #[allow(dead_code)] // not used on emscripten

--- a/library/unwind/Cargo.toml
+++ b/library/unwind/Cargo.toml
@@ -16,7 +16,7 @@ doc = false
 
 [dependencies]
 core = { path = "../core" }
-libc = { version = "0.2.79", features = ['rustc-dep-of-std'], default-features = false }
+libc = { git = "https://github.com/ivmarkov/libc.git", branch = "version_0.2.98", features = ['rustc-dep-of-std'], default-features = false }
 compiler_builtins = "0.1.0"
 cfg-if = "0.1.8"
 

--- a/library/unwind/src/lib.rs
+++ b/library/unwind/src/lib.rs
@@ -13,6 +13,7 @@ cfg_if::cfg_if! {
     } else if #[cfg(any(
         target_os = "l4re",
         target_os = "none",
+        target_os = "espidf",
     ))] {
         // These "unix" family members do not have unwinder.
         // Note this also matches x86_64-unknown-none-linuxkernel.


### PR DESCRIPTION
This is a cleaned up version of 5 commits:
- Each commit can be applied independently from the others (of course, you might want to apply the majority of those)
- The commits' comments should be relatively self-descriptive

Functionality:
- Commit 1 & 2: "espidf"-specific targets for Xtensa as well as the RiscV family of Espressif chips (targets naming and contents as discussed the other day)
- Commit 3: The patch against Rust STD itself (library/std)
- Commit 4: Updates to README.md
- Commit 5: Temporal introduction of a forked libc crate, so that all the stuff works for the esp32c3 chip as well

By the way - as unpleasant as it sounds, we might need to **temporarily** host the libc fork also in the esp-rs org (currently hosted in my personal space). It contains what it amounts to 5 line changes, so I hope these would be upstreamed quickly.
 