### PR TITLE
Add Xtensa asm!() esp32 target

### DIFF
--- a/compiler/rustc_codegen_llvm/src/asm.rs
+++ b/compiler/rustc_codegen_llvm/src/asm.rs
@@ -289,6 +289,7 @@ impl AsmBuilderMethods<'tcx> for Builder<'a, 'll, 'tcx> {
                 InlineAsmArch::SpirV => {}
                 InlineAsmArch::Wasm32 => {}
                 InlineAsmArch::Bpf => {}
+                InlineAsmArch::Xtensa => {}
             }
         }
         if !options.contains(InlineAsmOptions::NOMEM) {
@@ -599,6 +600,9 @@ fn reg_to_llvm(reg: InlineAsmRegOrRegClass, layout: Option<&TyAndLayout<'tcx>>) 
             InlineAsmRegClass::SpirV(SpirVInlineAsmRegClass::reg) => {
                 bug!("LLVM backend does not support SPIR-V")
             }
+            InlineAsmRegClass::Xtensa(XtensaInlineAsmRegClass::reg) => "r",
+            InlineAsmRegClass::Xtensa(XtensaInlineAsmRegClass::reg_bool) => "b",
+            InlineAsmRegClass::Xtensa(XtensaInlineAsmRegClass::freg) => "f",
             InlineAsmRegClass::Err => unreachable!(),
         }
         .to_string(),
@@ -668,6 +672,7 @@ fn modifier_to_llvm(
         InlineAsmRegClass::SpirV(SpirVInlineAsmRegClass::reg) => {
             bug!("LLVM backend does not support SPIR-V")
         }
+        InlineAsmRegClass::Xtensa(_) => None,
         InlineAsmRegClass::Err => unreachable!(),
     }
 }
@@ -717,6 +722,9 @@ fn dummy_output_type(cx: &CodegenCx<'ll, 'tcx>, reg: InlineAsmRegClass) -> &'ll 
         InlineAsmRegClass::SpirV(SpirVInlineAsmRegClass::reg) => {
             bug!("LLVM backend does not support SPIR-V")
         }
+        InlineAsmRegClass::Xtensa(XtensaInlineAsmRegClass::reg) => cx.type_i32(),
+        InlineAsmRegClass::Xtensa(XtensaInlineAsmRegClass::reg_bool) => cx.type_i1(),
+        InlineAsmRegClass::Xtensa(XtensaInlineAsmRegClass::freg) => cx.type_f32(),
         InlineAsmRegClass::Err => unreachable!(),
     }
 }

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -952,6 +952,7 @@ symbols! {
         reg32,
         reg64,
         reg_abcd,
+        reg_bool,
         reg_byte,
         reg_nonzero,
         reg_thumb,

--- a/compiler/rustc_target/src/asm/xtensa.rs
+++ b/compiler/rustc_target/src/asm/xtensa.rs
@@ -1,0 +1,185 @@
+use super::{InlineAsmArch, InlineAsmType};
+use rustc_macros::HashStable_Generic;
+use std::fmt;
+
+def_reg_class! {
+    Xtensa XtensaInlineAsmRegClass {
+        reg,
+        reg_bool,
+        freg,
+    }
+}
+
+impl XtensaInlineAsmRegClass {
+    pub fn valid_modifiers(self, _arch: super::InlineAsmArch) -> &'static [char] {
+        &[]
+    }
+
+    pub fn suggest_class(self, _arch: InlineAsmArch, _ty: InlineAsmType) -> Option<Self> {
+        None
+    }
+
+    pub fn suggest_modifier(
+        self,
+        _arch: InlineAsmArch,
+        _ty: InlineAsmType,
+    ) -> Option<(char, &'static str)> {
+        None
+    }
+
+    pub fn default_modifier(self, _arch: InlineAsmArch) -> Option<(char, &'static str)> {
+        None
+    }
+
+    pub fn supported_types(
+        self,
+        _arch: InlineAsmArch,
+    ) -> &'static [(InlineAsmType, Option<&'static str>)] {
+        match self {
+            Self::reg | Self::reg_bool => types! { _: I8, I16, I32; },
+            Self::freg => types! { _: F32, F64; },
+        }
+    }
+}
+
+def_regs! {
+    Xtensa XtensaInlineAsmReg XtensaInlineAsmRegClass {
+        a0: reg = ["a0"],
+        sp: reg = ["sp", "a1"],
+        a2: reg = ["a2"],
+        a3: reg = ["a3"],
+        a4: reg = ["a4"],
+        a5: reg = ["a5"],
+        a6: reg = ["a6"],
+        a7: reg = ["a7"],
+        a8: reg = ["a8"],
+        a9: reg = ["a9"],
+        a10: reg = ["a10"],
+        a11: reg = ["a11"],
+        a12: reg = ["a12"],
+        a13: reg = ["a13"],
+        a14: reg = ["a14"],
+        a15: reg = ["a15"],
+        lbeg: reg = ["lbeg"],
+        lend: reg = ["lend"],
+        lcount: reg = ["lcount"],
+        sar: reg = ["sar"],
+        br: reg = ["br"],
+        litbase: reg = ["litbase"],
+        scompare1: reg = ["scompare1"],
+        acclo: reg = ["acclo"],
+        acchi: reg = ["acchi"],
+        m0: reg = ["m0"],
+        m1: reg = ["m1"],
+        m2: reg = ["m2"],
+        m3: reg = ["m3"],
+        windowbase: reg = ["windowbase"],
+        windowstart: reg = ["windowstart"],
+        ibreakenable: reg = ["ibreakenable"],
+        memctl: reg = ["memctl"],
+        atomctl: reg = ["atomctl"],
+        ddr: reg = ["ddr"],
+        ibreaka0: reg = ["ibreaka0"],
+        ibreaka1: reg = ["ibreaka1"],
+        dbreaka0: reg = ["dbreaka0"],
+        dbreaka1: reg = ["dbreaka1"],
+        dbreakc0: reg = ["dbreakc0"],
+        dbreakc1: reg = ["dbreakc1"],
+        configid0: reg = ["configid0"],
+        epc1: reg = ["epc1"],
+        epc2: reg = ["epc2"],
+        epc3: reg = ["epc3"],
+        epc4: reg = ["epc4"],
+        epc5: reg = ["epc5"],
+        epc6: reg = ["epc6"],
+        epc7: reg = ["epc7"],
+        depc: reg = ["depc"],
+        eps2: reg = ["eps2"],
+        eps3: reg = ["eps3"],
+        eps4: reg = ["eps4"],
+        eps5: reg = ["eps5"],
+        eps6: reg = ["eps6"],
+        eps7: reg = ["eps7"],
+        configid1: reg = ["configid1"],
+        excsave1: reg = ["excsave1"],
+        excsave2: reg = ["excsave2"],
+        excsave3: reg = ["excsave3"],
+        excsave4: reg = ["excsave4"],
+        excsave5: reg = ["excsave5"],
+        excsave6: reg = ["excsave6"],
+        excsave7: reg = ["excsave7"],
+        cpenable: reg = ["cpenable"],
+        interrupt: reg = ["interrupt"],
+        intclear: reg = ["intclear"],
+        intenable: reg = ["intenable"],
+        ps: reg = ["ps"],
+        vecbase: reg = ["vecbase"],
+        exccause: reg = ["exccause"],
+        debugcause: reg = ["debugcause"],
+        ccount: reg = ["ccount"],
+        prid: reg = ["prid"],
+        icount: reg = ["icount"],
+        icountlevel: reg = ["icountlevel"],
+        excvaddr: reg = ["excvaddr"],
+        ccompare0: reg = ["ccompare0"],
+        ccompare1: reg = ["ccompare1"],
+        ccompare2: reg = ["ccompare2"],
+        misc0: reg = ["misc0"],
+        misc1: reg = ["misc1"],
+        misc2: reg = ["misc2"],
+        misc3: reg = ["misc3"],
+        gpio_out: reg = ["gpio_out"],
+        expstate: reg = ["expstate"],
+        threadptr: reg = ["threadptr"],
+        fcr: reg = ["fcr"],
+        fsr: reg = ["fsr"],
+        f64r_lo: reg = ["f64r_lo"],
+        f64r_hi: reg = ["f64r_hi"],
+        f64s: reg = ["f64s"],
+        f0: freg = ["f0"],
+        f1: freg = ["f1"],
+        f2: freg = ["f2"],
+        f3: freg = ["f3"],
+        f4: freg = ["f4"],
+        f5: freg = ["f5"],
+        f6: freg = ["f6"],
+        f7: freg = ["f7"],
+        f8: freg = ["f8"],
+        f9: freg = ["f9"],
+        f10: freg = ["f10"],
+        f11: freg = ["f11"],
+        f12: freg = ["f12"],
+        f13: freg = ["f13"],
+        f14: freg = ["f14"],
+        f15: freg = ["f15"],
+        b0: reg_bool = ["b0"],
+        b1: reg_bool = ["b1"],
+        b2: reg_bool = ["b2"],
+        b3: reg_bool = ["b3"],
+        b4: reg_bool = ["b4"],
+        b5: reg_bool = ["b5"],
+        b6: reg_bool = ["b6"],
+        b7: reg_bool = ["b7"],
+        b8: reg_bool = ["b8"],
+        b9: reg_bool = ["b9"],
+        b10: reg_bool = ["b10"],
+        b11: reg_bool = ["b11"],
+        b12: reg_bool = ["b12"],
+        b13: reg_bool = ["b13"],
+        b14: reg_bool = ["b14"],
+        b15: reg_bool = ["b15"],
+    }
+}
+
+impl XtensaInlineAsmReg {
+    pub fn emit(
+        self,
+        out: &mut dyn fmt::Write,
+        _arch: InlineAsmArch,
+        _modifier: Option<char>,
+    ) -> fmt::Result {
+        out.write_str(self.name())
+    }
+
+    pub fn overlapping_regs(self, mut _cb: impl FnMut(XtensaInlineAsmReg)) {}
+}

--- a/src/doc/unstable-book/src/library-features/asm.md
+++ b/src/doc/unstable-book/src/library-features/asm.md
@@ -31,6 +31,7 @@ Inline assembly is currently supported on the following architectures:
 - MIPS32r2 and MIPS64r2
 - wasm32
 - BPF
+- Xtensa
 
 ## Basic usage
 
@@ -461,7 +462,7 @@ options := "options(" option *["," option] [","] ")"
 asm := "asm!(" format_string *("," format_string) *("," [ident "="] operand) ["," options] [","] ")"
 ```
 
-The macro will initially be supported only on ARM, AArch64, Hexagon, PowerPC, x86, x86-64 and RISC-V targets. Support for more targets may be added in the future. The compiler will emit an error if `asm!` is used on an unsupported target.
+The macro will initially be supported only on ARM, AArch64, Hexagon, PowerPC, x86, x86-64, RISC-V and Xtensa targets. Support for more targets may be added in the future. The compiler will emit an error if `asm!` is used on an unsupported target.
 
 [format-syntax]: https://doc.rust-lang.org/std/fmt/#syntax
 
@@ -573,6 +574,20 @@ Here is the list of currently supported register classes:
 | wasm32 | `local` | None\* | `r` |
 | BPF | `reg` | `r[0-10]` | `r` |
 | BPF | `wreg` | `w[0-10]` | `w` |
+| Xtensa | `reg` | `a[0-15]`, `lbeg`, `lend`, `lcount` | `r` |
+| Xtensa | `reg` | `sar`, `br`, `litbase`, `scompare1` | `r` |
+| Xtensa | `reg` | `acclo`, `acchi`, `m0`, `m1`, `m2`, `m3` | `r` |
+| Xtensa | `reg` | `windowbase`, `windowstart`, `ibreakenable`, `memctl`, `atomctl`, `ddr` | `r` |
+| Xtensa | `reg` | `ibreaka0`, `ibreaka1`, `dbreaka0`, `dbreaka1`, `dbreakc0`, `dbreakc1`, `configid[0-1]` | `r` |
+| Xtensa | `reg` | `epc[1-7]`, `depc`, `eps[2-7]` | `r` |
+| Xtensa | `reg` | `excsave[1-7]`, `cpenable`, `interrupt`, `intclear`, `intenable` | `r` |
+| Xtensa | `reg` | `ps`, `vecbase`, `exccause`, `debugcause`, `ccount` | `r` |
+| Xtensa | `reg` | `prid`, `icount`, `icountlevel`, `excvaddr`, `ccompare[0-2]` | `r` |
+| Xtensa | `reg` | `excsave[1-7]`, `cpenable`, `interrupt`, `intclear`, `intenable` | `r` |
+| Xtensa | `reg` | `misc[0-3]`, `gpio_out`, `expstate`, `threadptr` | `r` |
+| Xtensa | `reg` | `fcr`, `fsr`, `f64r_lo`, `f64r_hi`, `f64s` | `r` |
+| Xtensa | `reg_bool` | `b[0-15]` | `b` |
+| Xtensa | `freg` | `f[0-10]` | `f` |
 
 > **Note**: On x86 we treat `reg_byte` differently from `reg` because the compiler can allocate `al` and `ah` separately whereas `reg` reserves the whole register.
 >
@@ -620,6 +635,9 @@ Each register class has constraints on which value types they can be used with. 
 | wasm32 | `local` | None | `i8` `i16` `i32` `i64` `f32` `f64` |
 | BPF | `reg` | None | `i8` `i16` `i32` `i64` |
 | BPF | `wreg` | `alu32` | `i8` `i16` `i32` |
+| Xtensa | `reg` | None | `i8`, `i16`, `i32` |
+| Xtensa | `reg_bool` | None | `i8`, `i16`, `i32` |
+| Xtensa | `freg` | None | `f32`, `f64` |
 
 > **Note**: For the purposes of the above table pointers, function pointers and `isize`/`usize` are treated as the equivalent integer type (`i16`/`i32`/`i64` depending on the target).
 
@@ -680,6 +698,7 @@ Some registers have multiple names. These are all treated by the compiler as ide
 | Hexagon | `r30` | `fr` |
 | Hexagon | `r31` | `lr` |
 | BPF | `r[0-10]` | `w[0-10]` |
+| Xtensa | `a1` | `sp` |
 
 Some registers cannot be used for input or output operands:
 
@@ -760,6 +779,9 @@ The supported modifiers are a subset of LLVM's (and GCC's) [asm template argumen
 | PowerPC | `reg` | None | `0` | None |
 | PowerPC | `reg_nonzero` | None | `3` | `b` |
 | PowerPC | `freg` | None | `0` | None |
+| Xtensa | `reg` | None | `a0` | None |
+| Xtensa | `reg_bool` | None | `b0` | None |
+| Xtensa | `freg` | None | `f0` | None |
 
 > Notes:
 > - on ARM `e` / `f`: this prints the low or high doubleword register name of a NEON quad (128-bit) register.


### PR DESCRIPTION
Located registers in the IDF source, so this probably needs checking by someone knowledgeable in this area as I am likely missing something. I have only tested using the "xtensa-rust-quickstart" after applying a minor fix to "esp32-hal".

> cargo espflash --chip esp32 --example alloc --speed 115200 --tool=cargo --features="xtensa-lx-rt/lx6,xtensa-lx/lx6,esp32-hal" COM3
 
Edit: Also modified the config.toml file.