### PR TITLE
README.md without prompts for easy copying

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ by running it with the `--help` flag or reading the [rustc dev guide][rustcguide
 2. Clone the [source] with `git`:
 
    ```sh
-   $ git clone https://github.com/rust-lang/rust.git
-   $ cd rust
+   git clone https://github.com/rust-lang/rust.git
+   cd rust
    ```
 
 [source]: https://github.com/rust-lang/rust
@@ -91,7 +91,7 @@ by running it with the `--help` flag or reading the [rustc dev guide][rustcguide
     Copy the default `config.toml.example` to `config.toml` to get started.
 
     ```sh
-    $ cp config.toml.example config.toml
+    cp config.toml.example config.toml
     ```
 
     If you plan to use `x.py install` to create an installation, it is recommended
@@ -102,7 +102,7 @@ by running it with the `--help` flag or reading the [rustc dev guide][rustcguide
 4. Build and install:
 
     ```sh
-    $ ./x.py build && ./x.py install
+   ./x.py build && ./x.py install
     ```
 
     When complete, `./x.py install` will place several programs into
@@ -161,7 +161,7 @@ build.
 4. Navigate to Rust's source code (or clone it), then build it:
 
    ```sh
-   $ ./x.py build && ./x.py install
+   ./x.py build && ./x.py install
    ```
 
 #### MSVC
@@ -179,7 +179,7 @@ With these dependencies installed, you can build the compiler in a `cmd.exe`
 shell with:
 
 ```sh
-> python x.py build
+python x.py build
 ```
 
 Currently, building Rust only works with some known versions of Visual Studio. If
@@ -188,8 +188,8 @@ you may need to force rustbuild to use an older version. This can be done
 by manually calling the appropriate vcvars file before running the bootstrap.
 
 ```batch
-> CALL "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
-> python x.py build
+CALL "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
+python x.py build
 ```
 
 #### Specifying an ABI
@@ -215,8 +215,8 @@ While it's not the recommended build system, this project also provides a
 configure script and makefile (the latter of which just invokes `x.py`).
 
 ```sh
-$ ./configure
-$ make && sudo make install
+./configure
+make && sudo make install
 ```
 
 When using the configure script, the generated `config.mk` file may override the
@@ -228,7 +228,7 @@ When using the configure script, the generated `config.mk` file may override the
 If you’d like to build the documentation, it’s almost the same:
 
 ```sh
-$ ./x.py doc
+./x.py doc
 ```
 
 The generated documentation will appear under `doc` in the `build` directory for


### PR DESCRIPTION
Removed several prompts, `$ ` and `> `, for convenient _copy and paste_.

When clicking on the _copy symbol_ while hovering over the \`\`\`  text block
gets the `$ ` also on the _clipboard paste buffer_.

For people who don't use webbrowser with JavaScript enabled is selecting
the two lines
   git clone https://github.com/rust-lang/rust.git
   cd rust
much easier as avoiding $ from
   $ git clone https://github.com/rust-lang/rust.git
   $ cd rust

Most  \`\`\` blocks are now consistent with the very first
    ./x.py <subcommand> [flags]