### PR TITLE
Fix alignment for values larger than 32 bit on xtensa targets

### DIFF
--- a/compiler/rustc_target/src/spec/xtensa_esp32_espidf.rs
+++ b/compiler/rustc_target/src/spec/xtensa_esp32_espidf.rs
@@ -5,7 +5,7 @@ pub fn target() -> Target {
     Target {
         llvm_target: "xtensa-none-elf".into(),
         pointer_width: 32,
-        data_layout: "e-m:e-p:32:32-i64:64-i128:128-n32".into(),
+        data_layout: "e-m:e-p:32:32-i64:32-i128:32-n32-f64:32".into(),
         arch: "xtensa".into(),
 
         options: TargetOptions {

--- a/compiler/rustc_target/src/spec/xtensa_esp32_none_elf.rs
+++ b/compiler/rustc_target/src/spec/xtensa_esp32_none_elf.rs
@@ -4,7 +4,7 @@ pub fn target() -> Target {
     Target {
         llvm_target: "xtensa-none-elf".into(),
         pointer_width: 32,
-        data_layout: "e-m:e-p:32:32-i64:64-i128:128-n32".into(),
+        data_layout: "e-m:e-p:32:32-i64:32-i128:32-n32-f64:32".into(),
         arch: "xtensa".into(),
         
         options: TargetOptions {

--- a/compiler/rustc_target/src/spec/xtensa_esp32s2_espidf.rs
+++ b/compiler/rustc_target/src/spec/xtensa_esp32s2_espidf.rs
@@ -5,7 +5,7 @@ pub fn target() -> Target {
     Target {
         llvm_target: "xtensa-none-elf".into(),
         pointer_width: 32,
-        data_layout: "e-m:e-p:32:32-i64:64-i128:128-n32".into(),
+        data_layout: "e-m:e-p:32:32-i64:32-i128:32-n32-f64:32".into(),
         arch: "xtensa".into(),
 
         options: TargetOptions {

--- a/compiler/rustc_target/src/spec/xtensa_esp32s2_none_elf.rs
+++ b/compiler/rustc_target/src/spec/xtensa_esp32s2_none_elf.rs
@@ -4,7 +4,7 @@ pub fn target() -> Target {
     Target {
         llvm_target: "xtensa-none-elf".into(),
         pointer_width: 32,
-        data_layout: "e-m:e-p:32:32-i64:64-i128:128-n32".into(),
+        data_layout: "e-m:e-p:32:32-i64:32-i128:32-n32-f64:32".into(),
         arch: "xtensa".into(),
         
         options: TargetOptions {

--- a/compiler/rustc_target/src/spec/xtensa_esp32s3_espidf.rs
+++ b/compiler/rustc_target/src/spec/xtensa_esp32s3_espidf.rs
@@ -5,7 +5,7 @@ pub fn target() -> Target {
     Target {
         llvm_target: "xtensa-none-elf".into(),
         pointer_width: 32,
-        data_layout: "e-m:e-p:32:32-i64:64-i128:128-n32".into(),
+        data_layout: "e-m:e-p:32:32-i64:32-i128:32-n32-f64:32".into(),
         arch: "xtensa".into(),
 
         options: TargetOptions {

--- a/compiler/rustc_target/src/spec/xtensa_esp32s3_none_elf.rs
+++ b/compiler/rustc_target/src/spec/xtensa_esp32s3_none_elf.rs
@@ -4,7 +4,7 @@ pub fn target() -> Target {
     Target {
         llvm_target: "xtensa-none-elf".into(),
         pointer_width: 32,
-        data_layout: "e-m:e-p:32:32-i64:64-i128:128-n32".into(),
+        data_layout: "e-m:e-p:32:32-i64:32-i128:32-n32-f64:32".into(),
         arch: "xtensa".into(),
         
         options: TargetOptions {

--- a/compiler/rustc_target/src/spec/xtensa_esp8266_none_elf.rs
+++ b/compiler/rustc_target/src/spec/xtensa_esp8266_none_elf.rs
@@ -4,7 +4,7 @@ pub fn target() -> Target {
     Target {
         llvm_target: "xtensa-none-elf".into(),
         pointer_width: 32,
-        data_layout: "e-m:e-p:32:32-i64:64-i128:128-n32".into(),
+        data_layout: "e-m:e-p:32:32-i64:32-i128:32-n32-f64:32".into(),
         arch: "xtensa".into(),
         
         options: TargetOptions {


### PR DESCRIPTION
32 bit is the maximum alignment required for any object on xtensa, indeed this is the maximum alignment that esp-idf's heap allocator guarantees.