### PR TITLE
Avoid emulating wider atomics

### DIFF
--- a/compiler/rustc_target/src/spec/xtensa_esp32_espidf.rs
+++ b/compiler/rustc_target/src/spec/xtensa_esp32_espidf.rs
@@ -20,9 +20,8 @@ pub fn target() -> Target {
             cpu: "esp32".into(),
             linker: Some("xtensa-esp32-elf-gcc".into()),
 
-            // The esp32 only supports native 32bit atomics. However, esp-idf will emulate 64bit atomics 
-            // so we claim a max atomic width of 64 here.
-            max_atomic_width: Some(64),
+            // esp-idf can emulate 64-bit atomics, but Rust eschews non-hardware atomics
+            max_atomic_width: Some(32),
             atomic_cas: true,
 
             ..super::xtensa_base::opts()

--- a/compiler/rustc_target/src/spec/xtensa_esp32s2_espidf.rs
+++ b/compiler/rustc_target/src/spec/xtensa_esp32s2_espidf.rs
@@ -22,15 +22,12 @@ pub fn target() -> Target {
 
             // See https://github.com/espressif/rust-esp32-example/issues/3#issuecomment-861054477
             //
-            // Unlike the original ESP32 chip, ESP32-S2 does not really support atomics.
-            // If the missing hardware instruction ends up being emulated in ESP-IDF, we might want to revert
-            // this change and claim that atomics are supported "in hardware" (even though they would be emulated
-            // by actually trapping the illegal instruction exception handler and calling into an ESP-IDF C emulation code).
+            // While the ESP32-S2 chip does not natively support atomics, ESP-IDF does support
+            // the __atomic* and __sync* compiler builtins. Setting `max_atomic_width` and `atomic_cas`
+            // and `atomic_cas: true` will cause the compiler to emit libcalls to these builtins.
             //
-            // However, for now we simultaneously claim "max_atomic_width: Some(64)" **and** atomic_cas: true,
-            // which should force the compiler to generate libcalls to functions that emulate atomics
-            // and which are already implemented in the ESP-IDF main branch anyway.
-            max_atomic_width: Some(64),
+            // Support for atomics is necessary for the Rust STD library, which is supported by ESP-IDF.
+            max_atomic_width: Some(32),
             atomic_cas: true,
 
             ..super::xtensa_base::opts()

--- a/compiler/rustc_target/src/spec/xtensa_esp32s3_espidf.rs
+++ b/compiler/rustc_target/src/spec/xtensa_esp32s3_espidf.rs
@@ -20,9 +20,8 @@ pub fn target() -> Target {
             cpu: "esp32-s3".into(),
             linker: Some("xtensa-esp32s3-elf-gcc".into()),
 
-            // The esp32s3 only supports native 32bit atomics. However, esp-idf will emulate 64bit atomics 
-            // so we claim a max atomic width of 64 here.
-            max_atomic_width: Some(64),
+            // esp-idf can emulate 64-bit atomics, but Rust eschews non-hardware atomics
+            max_atomic_width: Some(32),
             atomic_cas: true,
 
             ..super::xtensa_base::opts()


### PR DESCRIPTION
Generally, Rust eschews emulating atomics where it can. This is done precisely so people can write interrupt handlers in Rust, without accidentally arriving in other interrupt handlers, or other complications that such things tend to induce.

No solution is yet proposed for the xtensa-esp32s2-espidf target. However, it would be less-than-ideal if an ecosystem grew up around Rust-on-Xtensa that was dependent on something historically rejected by upstream Rust in the cases where it was easily avoidable.