### PR TITLE
Fix esp-idf-sys#278

### DIFF
--- a/compiler/rustc_target/src/spec/targets/xtensa_esp32_espidf.rs
+++ b/compiler/rustc_target/src/spec/targets/xtensa_esp32_espidf.rs
@@ -5,7 +5,7 @@ pub fn target() -> Target {
     Target {
         llvm_target: "xtensa-none-elf".into(),
         pointer_width: 32,
-        data_layout: "e-m:e-p:32:32-i64:64-i128:128-n32".into(),
+        data_layout: "e-m:e-p:32:32-i64:32-i128:32-n32".into(),
         arch: "xtensa".into(),
 
         options: TargetOptions {

--- a/compiler/rustc_target/src/spec/targets/xtensa_esp32_none_elf.rs
+++ b/compiler/rustc_target/src/spec/targets/xtensa_esp32_none_elf.rs
@@ -5,7 +5,7 @@ pub fn target() -> Target {
     Target {
         llvm_target: "xtensa-none-elf".into(),
         pointer_width: 32,
-        data_layout: "e-m:e-p:32:32-i64:64-i128:128-n32".into(),
+        data_layout: "e-m:e-p:32:32-i64:32-i128:32-n32".into(),
         arch: "xtensa".into(),
         
         options: TargetOptions {

--- a/compiler/rustc_target/src/spec/targets/xtensa_esp32s2_espidf.rs
+++ b/compiler/rustc_target/src/spec/targets/xtensa_esp32s2_espidf.rs
@@ -5,7 +5,7 @@ pub fn target() -> Target {
     Target {
         llvm_target: "xtensa-none-elf".into(),
         pointer_width: 32,
-        data_layout: "e-m:e-p:32:32-i64:64-i128:128-n32".into(),
+        data_layout: "e-m:e-p:32:32-i64:32-i128:32-n32".into(),
         arch: "xtensa".into(),
 
         options: TargetOptions {

--- a/compiler/rustc_target/src/spec/targets/xtensa_esp32s2_none_elf.rs
+++ b/compiler/rustc_target/src/spec/targets/xtensa_esp32s2_none_elf.rs
@@ -4,7 +4,7 @@ pub fn target() -> Target {
     Target {
         llvm_target: "xtensa-none-elf".into(),
         pointer_width: 32,
-        data_layout: "e-m:e-p:32:32-i64:64-i128:128-n32".into(),
+        data_layout: "e-m:e-p:32:32-i64:32-i128:32-n32".into(),
         arch: "xtensa".into(),
         
         options: TargetOptions {

--- a/compiler/rustc_target/src/spec/targets/xtensa_esp32s3_espidf.rs
+++ b/compiler/rustc_target/src/spec/targets/xtensa_esp32s3_espidf.rs
@@ -5,7 +5,7 @@ pub fn target() -> Target {
     Target {
         llvm_target: "xtensa-none-elf".into(),
         pointer_width: 32,
-        data_layout: "e-m:e-p:32:32-i64:64-i128:128-n32".into(),
+        data_layout: "e-m:e-p:32:32-i64:32-i128:32-n32".into(),
         arch: "xtensa".into(),
 
         options: TargetOptions {

--- a/compiler/rustc_target/src/spec/targets/xtensa_esp32s3_none_elf.rs
+++ b/compiler/rustc_target/src/spec/targets/xtensa_esp32s3_none_elf.rs
@@ -4,7 +4,7 @@ pub fn target() -> Target {
     Target {
         llvm_target: "xtensa-none-elf".into(),
         pointer_width: 32,
-        data_layout: "e-m:e-p:32:32-i64:64-i128:128-n32".into(),
+        data_layout: "e-m:e-p:32:32-i64:32-i128:32-n32".into(),
         arch: "xtensa".into(),
         
         options: TargetOptions {

--- a/compiler/rustc_target/src/spec/targets/xtensa_esp8266_none_elf.rs
+++ b/compiler/rustc_target/src/spec/targets/xtensa_esp8266_none_elf.rs
@@ -4,7 +4,7 @@ pub fn target() -> Target {
     Target {
         llvm_target: "xtensa-none-elf".into(),
         pointer_width: 32,
-        data_layout: "e-m:e-p:32:32-i64:64-i128:128-n32".into(),
+        data_layout: "e-m:e-p:32:32-i64:32-i128:32-n32".into(),
         arch: "xtensa".into(),
         
         options: TargetOptions {


### PR DESCRIPTION
@MabezDev This is fixing [this issue](https://github.com/esp-rs/esp-idf-sys/issues/278) in `esp-idf-sys`.

The TL;DR is that xtensa GCC aligns 64 and 128 bit values at the 4 byte boundary, while our rust `xtensa` targets align these at their default, i.e. at the 8 and 16th byte boundary, which leads to rust panicking at runtime if it finds a GCC-provided structure, which - from its POV - is misaligned.

The fix is simply aligning (pun intended) the Rust/LLVM alignment spec with the one in xtensa GCC.

While this is crucial for the `esp-idf-*` crates (and therefore the `-espidf` targets), I suspect it might be a thing for the baremetal targets too, considering the WIFI and BLE blobs, as well as the `mbed-tls` usage on baremetal (whatever the status of that last project is).

Hence I touched these too.

Let me know if I have to rebase the PR against a different branch. Not really sure what is the git workflow policy of the `esp-rs` Rust fork these days.

