### PR TITLE
Convert libc::SIGABRT to i32

### DIFF
--- a/library/test/src/test_result.rs
+++ b/library/test/src/test_result.rs
@@ -93,13 +93,14 @@ pub fn get_result_from_exit_code(
     time_opts: &Option<time::TestTimeOptions>,
     exec_time: &Option<time::TestExecTime>,
 ) -> TestResult {
+    let _sigabrt = libc::SIGABRT as i32;
     let result = match status.code() {
         Some(TR_OK) => TestResult::TrOk,
         #[cfg(windows)]
         Some(STATUS_ABORTED) => TestResult::TrFailed,
         #[cfg(unix)]
         None => match status.signal() {
-            Some(libc::SIGABRT) => TestResult::TrFailed,
+            Some(_sigabrt) => TestResult::TrFailed,
             Some(signal) => {
                 TestResult::TrFailedMsg(format!("child process exited with signal {signal}"))
             }


### PR DESCRIPTION
#231 
Temporarily use a private variable _sigabrt to hold the value of status.signal() for comparison