### PR TITLE
Add XTENSA_ALLOWED_FEATURES to supported_target_features

### DIFF
--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -566,6 +566,7 @@ impl super::spec::Target {
             "csky" => CSKY_ALLOWED_FEATURES,
             "loongarch64" => LOONGARCH_ALLOWED_FEATURES,
             "s390x" => IBMZ_ALLOWED_FEATURES,
+            "xtensa" => XTENSA_ALLOWED_FEATURES,
             _ => &[],
         }
     }


### PR DESCRIPTION
This fixes an issue that target_feature is not handled correctly.

Currently, `cfg(target_feature)` does not work, and inline assembly incorrectly rejects registers that depend on a particular target_feature.

e.g., freg, scompare1, etc. are rejected even on esp32.

```
error: register class `freg` requires at least one of the following target features: dfpaccel, fp
  --> /Users/taiki/projects/forks/rust-lang/rust/tests/assembly/asm/xtensa-types.rs:62:44
   |
62 |             asm!(concat!($mov, " {}, {}"), out($class) y, in($class) x);
   |                                            ^^^^^^^^^^^^^
...
96 | check_general_reg!(freg_f32 f32 freg "mov.s");
   | --------------------------------------------- in this macro invocation
   |
   = note: this error originates in the macro `check_general_reg` (in Nightly builds, run with -Z macro-backtrace for more info)
```